### PR TITLE
Add extra-libraries to link libstdc++

### DIFF
--- a/ffi-experimental.cabal
+++ b/ffi-experimental.cabal
@@ -23,7 +23,7 @@ executable ffi-experimental
                      , optparse-applicative == 0.14.3.0
                      , show-prettyprint == 0.2.2
                      , yaml == 0.11.0.0
-
+  extra-libraries:     stdc++
 executable cpp-test
   hs-source-dirs:      src
   main-is:             CppTest.hs
@@ -31,4 +31,5 @@ executable cpp-test
   build-depends:       base >= 4.7 && < 5
                      , inline-c-cpp == 0.3.0.1
                      , optparse-applicative == 0.14.3.0
+  extra-libraries:     stdc++
 


### PR DESCRIPTION
In ubuntu 18.04, link fails. The error log is below.
This PR adds libstdc++.

```
$ stack build
...
show-prettyprint-0.2.2: download
show-prettyprint-0.2.2: configure
show-prettyprint-0.2.2: build
show-prettyprint-0.2.2: copy/register
Building all executables for `ffi-experimental' once. After a successful build of all of them, only specified executables wilbe rebuilt.
ffi-experimental-0.1.0.0: configure (exe)
Configuring ffi-experimental-0.1.0.0...
ffi-experimental-0.1.0.0: build (exe)
Preprocessing executable 'cpp-test' for ffi-experimental-0.1.0.0..
Building executable 'cpp-test' for ffi-experimental-0.1.0.0..
[1 of 1] Compiling Main             ( src/CppTest.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmpain.o )
Linking .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test ...
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function inline_c_Main_0: error: undined reference to 'std::cout'
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function inline_c_Main_0: error: undined reference to 'std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(st:basic_ostream<char, std::char_traits<char> >&, char const*, long)'
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function inline_c_Main_0: error: undined reference to 'std::cout'
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function inline_c_Main_0: error: undined reference to 'std::ostream::operator<<(int)'
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function inline_c_Main_0: error: undined reference to 'std::ostream::put(char)'
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function inline_c_Main_0: error: undined reference to 'std::ostream::flush()'
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function inline_c_Main_0: error: undined reference to 'std::__throw_bad_cast()'
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function inline_c_Main_0: error: undined reference to 'std::ctype<char>::_M_widen_init() const'
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function _GLOBAL__sub_I_inline_c_Mai0: error: undefined reference to 'std::ios_base::Init::Init()'
.stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/cpp-test/cpp-test-tmp/Main.o:ghc_1.cpp:function _GLOBAL__sub_I_inline_c_Mai0: error: undefined reference to 'std::ios_base::Init::~Init()'
collect2: error: ld returned 1 exit status
`gcc' failed in phase `Linker'. (Exit code: 1)
Completed 68 action(s).

--  While building custom Setup.hs for package ffi-experimental-0.1.0.0 using:
      /home/junji-hashimoto/.stack/setup-exe-cache/x86_64-linux/Cabal-simple_mPHDZzAJ_2.4.0.1_ghc-8.6.3 --builddir=.stack-wordist/x86_64-linux/Cabal-2.4.0.1 build exe:cpp-test exe:ffi-experimental --ghc-options " -ddump-hi -ddump-to-file -fdiagnosticcolor=always"
    Process exited with code: ExitFailure 1
```