### PR TITLE
Add _GLIBCXX_USE_CXX11_ABI=0 for linux

### DIFF
--- a/ffi/ffi.cabal
+++ b/ffi/ffi.cabal
@@ -18,7 +18,10 @@ executable ffi-test
   build-depends:       base >= 4.7 && < 5
                      , inline-c-cpp >= 0.3.0.1
                      , optparse-applicative >= 0.14.3.0
-  extra-libraries:     stdc++, iomp5, mklml, torch
-  ghc-options:         -optc-std=c++14
-  -- cc-options:          -std=c++14
-
+  extra-libraries:     stdc++
+                     , c10
+                     , iomp5
+                     , mklml
+                     , caffe2
+                     , torch
+  ghc-options:         -optc-std=c++14 -optc-D_GLIBCXX_USE_CXX11_ABI=0


### PR DESCRIPTION
In linux, following linker-errors happen.
This is because libtorch uses [GLIBCXX_USE_CXX11_ABI=0](https://discuss.pytorch.org/t/issues-linking-with-libtorch-c-11-abi/29510/3).
The flag forces GCC to use the old C++11 ABI.
So this PR adds ```GLIBCXX_USE_CXX11_ABI=0```.

```
[junji-hashimoto@ ffi-experimental] (dev)$ cabal new-build all
Resolving dependencies...
Build profile: -w ghc-8.4.4 -O1
In order, the following will be built (use -v for more details):
 - ffi-0.1.0.0 (exe:ffi-test) (configuration changed)
Warning: ffi.cabal:30:3: The field "cxx-options" is available since Cabal
[2,1]
Configuring executable 'ffi-test' for ffi-0.1.0.0..
Preprocessing executable 'ffi-test' for ffi-0.1.0.0..
Building executable 'ffi-test' for ffi-0.1.0.0..
Linking /home/junji-hashimoto/git/hasktorch/ffi-experimental/dist-newstyle/build/x86_64-linux/ghc-8.4.4/ffi-0.1.0.0/x/ffi-test/build/ffi-test/ffi-test ...
cc1: warning: command line option ‘-std=c++14’ is valid for C++/ObjC++ but not for C
/home/junji-hashimoto/git/hasktorch/ffi-experimental/dist-newstyle/build/x86_64-linux/ghc-8.4.4/ffi-0.1.0.0/x/ffi-test/build/ffi-test/ffi-test-tmp/Main.o:ghc_4.cpp:function inline_c_Main_0: error: undefined reference to 'c10::Symbol::fromQualString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/home/junji-hashimoto/git/hasktorch/ffi-experimental/dist-newstyle/build/x86_64-linux/ghc-8.4.4/ffi-0.1.0.0/x/ffi-test/build/ffi-test/ffi-test-tmp/Main.o:ghc_4.cpp:function inline_c_Main_0: error: undefined reference to 'c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/home/junji-hashimoto/git/hasktorch/ffi-experimental/dist-newstyle/build/x86_64-linux/ghc-8.4.4/ffi-0.1.0.0/x/ffi-test/build/ffi-test/ffi-test-tmp/Main.o:ghc_4.cpp:function inline_c_Main_0: error: undefined reference to 'c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/home/junji-hashimoto/git/hasktorch/ffi-experimental/dist-newstyle/build/x86_64-linux/ghc-8.4.4/ffi-0.1.0.0/x/ffi-test/build/ffi-test/ffi-test-tmp/Main.o:ghc_4.cpp:function inline_c_Main_0: error: undefined reference to 'c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/home/junji-hashimoto/git/hasktorch/ffi-experimental/dist-newstyle/build/x86_64-linux/ghc-8.4.4/ffi-0.1.0.0/x/ffi-test/build/ffi-test/ffi-test-tmp/Main.o:ghc_4.cpp:function inline_c_Main_0: error: undefined reference to 'c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/home/junji-hashimoto/git/hasktorch/ffi-experimental/dist-newstyle/build/x86_64-linux/ghc-8.4.4/ffi-0.1.0.0/x/ffi-test/build/ffi-test/ffi-test-tmp/Main.o:ghc_4.cpp:function inline_c_Main_1: error: undefined reference to 'c10::Symbol::fromQualString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/home/junji-hashimoto/git/hasktorch/ffi-experimental/dist-newstyle/build/x86_64-linux/ghc-8.4.4/ffi-0.1.0.0/x/ffi-test/build/ffi-test/ffi-test-tmp/Main.o:ghc_4.cpp:function torch::randn(c10::ArrayRef<long>, c10::TensorOptions const&): error: undefined reference to 'c10::Symbol::fromQualString(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
`gcc' failed in phase `Linker'. (Exit code: 1)
```