### PR TITLE
Add PtrTensor-type to use torch::Tensor's pointer

### DIFF
--- a/ffi/CppTest.hs
+++ b/ffi/CppTest.hs
@@ -11,18 +11,36 @@ run in ghci using:
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Main where
 
 import qualified Language.C.Inline.Cpp as C
 import qualified Language.C.Inline.Cpp.Exceptions as C
+import qualified Language.C.Inline.Context as C
+import qualified Language.C.Types as C
+import qualified Data.Map as Map
 
-C.context C.cppCtx
+import Foreign.C.String
+import Foreign.C.Types
+import Foreign
+
+data Tensor
+
+C.context $ C.cppCtx <> mempty {
+    C.ctxTypesTable = Map.fromList [
+      (C.TypeName "PtrTensor", [t|Ptr Tensor|])
+    ]
+}
 
 C.include "<iostream>"
 C.include "<torch/torch.h>"
 C.include "<torch/csrc/autograd/variable.h>"
 C.include "<torch/csrc/autograd/function.h>"
+
+-- inline-c can not parse c++'s symbol like torch::Tensor which includes "::".
+-- "helper.h" defines "typedef torch::Tensor* PtrTensor;" to remove "::".
+C.include "helper.h"
 
 testInit :: IO ()
 testInit = do
@@ -40,6 +58,20 @@ testAutograd = do
         auto c = a + b;
         c.backward();
         std::cout << a << std::endl << b << std::endl << c << std::endl;
+    } |]
+    [C.block| void {
+        std::cout << "Hello torch!" << std::endl;
+    } |]
+    a2 <- [C.block| PtrTensor {
+      return new torch::Tensor(torch::ones({2, 2}, torch::requires_grad()));
+    } |]
+    b2 <- [C.block| PtrTensor {
+      return new torch::Tensor(torch::randn({2, 2}));
+    } |]
+    [C.block| void {
+        auto c2 = *$(PtrTensor a2) + *$(PtrTensor b2);
+        c2.backward();
+        std::cout << *$(PtrTensor a2) << std::endl << *$(PtrTensor b2) << std::endl << c2 << std::endl;
     } |]
 
 testResource :: IO ()

--- a/ffi/ffi.cabal
+++ b/ffi/ffi.cabal
@@ -18,7 +18,10 @@ executable ffi-test
   build-depends:       base >= 4.7 && < 5
                      , inline-c-cpp >= 0.3.0.1
                      , optparse-applicative >= 0.14.3.0
-  extra-libraries:     stdc++, iomp5, mklml, torch
-  ghc-options:         -optc-std=c++14
-  -- cc-options:          -std=c++14
-
+  extra-libraries:     stdc++
+                     , c10
+                     , iomp5
+                     , mklml
+                     , caffe2
+                     , torch
+  ghc-options:         -optc-std=c++14 -optc-D_GLIBCXX_USE_CXX11_ABI=0

--- a/ffi/ffi.cabal
+++ b/ffi/ffi.cabal
@@ -17,7 +17,9 @@ executable ffi-test
   default-language:    Haskell2010
   build-depends:       base >= 4.7 && < 5
                      , inline-c-cpp >= 0.3.0.1
+                     , inline-c
                      , optparse-applicative >= 0.14.3.0
+                     , containers
   extra-libraries:     stdc++
                      , c10
                      , iomp5

--- a/ffi/helper.h
+++ b/ffi/helper.h
@@ -1,0 +1,1 @@
+typedef torch::Tensor* PtrTensor;


### PR DESCRIPTION
This PR adds the pointer type of torch::Tensor and makes it possible to generate torch::Tensor by haskell.
I am worry about overhead of ```new torch::Tensor``` which makes heap-object from stack-object.
Next, I will make c_xxx functions like c_add of ffi(see below).

```
ffi/th/src/Torch/FFI/TH/Byte/TensorMath.hs:c_add :: Ptr C'THState -> Ptr C'THByteTensor -> Ptr C'THByteTensor -> CUChar -> IO ()
```
