### PR TITLE
Add the parser of Declarations.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - run: echo $LD_LIBRARY_PATH
       - run: apt update -qq && apt install -y cmake wget unzip git libtinfo-dev python3 python3-yaml
+      - run: update-alternatives --install /usr/bin/python python /usr/bin/python3 1
       - checkout
       - run: git submodule init && git submodule update
       - run: wget -qO- https://get.haskellstack.org/ | sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       LD_LIBRARY_PATH: /root/project/deps/libtorch/lib:/root/project/deps/mklml/lib
     steps:
       - run: echo $LD_LIBRARY_PATH
-      - run: apt update -qq && apt install -y cmake wget unzip git libtinfo-dev
+      - run: apt update -qq && apt install -y cmake wget unzip git libtinfo-dev python python-yaml
       - checkout
       - run: git submodule init && git submodule update
       - run: wget -qO- https://get.haskellstack.org/ | sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       LD_LIBRARY_PATH: /root/project/deps/libtorch/lib:/root/project/deps/mklml/lib
     steps:
       - run: echo $LD_LIBRARY_PATH
-      - run: apt update -qq && apt install -y cmake wget unzip git libtinfo-dev python python-yaml
+      - run: apt update -qq && apt install -y cmake wget unzip git libtinfo-dev python3 python3-yaml
       - checkout
       - run: git submodule init && git submodule update
       - run: wget -qO- https://get.haskellstack.org/ | sh

--- a/codegen/codegen.cabal
+++ b/codegen/codegen.cabal
@@ -15,6 +15,7 @@ library
   exposed-modules:
     ParseNativeFunctions
     ParseNN
+    ParseDeclarations
     ParseDerivatives
     ParseFunctionSig
     ParseHeadersForNN

--- a/codegen/src/ParseDeclarations.hs
+++ b/codegen/src/ParseDeclarations.hs
@@ -1,0 +1,92 @@
+
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module ParseDeclarations where
+
+import Data.Char (toUpper)
+import GHC.Generics
+import Data.Yaml
+
+import qualified Data.Yaml as Y
+import Data.Aeson.Types (defaultOptions, fieldLabelModifier, genericParseJSON)
+import qualified Language.C.Inline.Cpp as C
+import qualified Language.C.Inline.Cpp.Exceptions as C
+import Text.Show.Prettyprint (prettyPrint)
+
+{- Declarations.yaml -}
+{- --A example--
+- name: _th_set_
+  matches_jit_signature: false
+  schema_string: ''
+  method_prefix_derived: ''
+  arguments:
+  - dynamic_type: Tensor
+    name: self
+    type: Tensor &
+  - dynamic_type: Storage
+    name: source
+    type: Storage
+  method_of:
+  - Type
+  - namespace
+  mode: TH
+  python_module: ''
+  buffers: []
+  returns:
+  - dynamic_type: Tensor
+    name: self
+    type: Tensor &
+  inplace: true
+  is_factory_method: false
+  abstract: true
+  requires_tensor: false
+  device_guard: false
+  with_gil: false
+  deprecated: false
+-}
+
+data Type = Type
+  { name' :: String
+  , dynamic_type' :: String
+  , type' :: String
+} deriving (Show, Generic)
+
+data Mode
+  = TH
+  | THC
+  deriving (Show, Generic)
+
+data Declaration = Derivative
+  { name :: String
+  , matches_jit_signature :: Bool
+  , schema_string :: [String]
+  , method_prefix_derived :: [String]
+  , arguments :: [Type]
+  , method_of :: [String]
+  , mode :: Mode
+  , python_module :: String
+  , buffers :: [String]
+  , returns :: Type
+  , inplace :: Bool
+  , is_factory_method :: Bool
+  , abstract :: Bool
+  , requires_tensor :: Bool
+  , device_guard :: Bool
+  , with_gil :: Bool
+  , deprecated :: Bool
+} deriving (Show, Generic)
+
+instance FromJSON Type where
+    parseJSON = genericParseJSON defaultOptions{ fieldLabelModifier = reverse.(drop 1).reverse }
+
+instance FromJSON Mode
+
+instance FromJSON Declaration
+
+
+decodeAndPrint :: String -> IO ()
+decodeAndPrint fileName = do
+  file <- Y.decodeFileEither fileName :: IO (Either ParseException [Declaration])
+  prettyPrint file

--- a/codegen/test/Spec.hs
+++ b/codegen/test/Spec.hs
@@ -29,6 +29,8 @@ main = hspec $ do
     describe "THNN.h Spec" thnnSpec
   describe "parsing derivatives.yaml" $ do
     describe "Derivatives Spec" derivativesSpec
+  describe "parsing Declarations.yaml" $ do
+    describe "Declarations Spec" declarationsSpec
 
 nativeFunctionsPath :: FilePath
 nativeFunctionsPath = "../spec/native_functions_modified.yaml"
@@ -291,4 +293,24 @@ vanillaParse fp = do
   doesFileExist fp >>= \case
     False -> throwString "Spec doesn't exist! Review README to get spec yaml"
     True -> Y.decodeFileThrow fp
+
+
+
+declarationsPath :: FilePath
+declarationsPath = "../spec/Declarations.yaml"
+
+declarationsSpec :: Spec
+declarationsSpec = do
+  xs <- runIO $ vanillaParse declarationsPath
+
+  it "parses the same number of stringy functions as a vanilla parsing" $ do
+    fs <- parseWith (Proxy @ Derivative)
+    (length fs) `shouldBe` (length xs)
+
+ where
+  parseWith :: forall funtype . Y.FromJSON funtype => Proxy funtype -> IO [funtype]
+  parseWith _ = do
+    Y.decodeFileEither declarationsPath >>= \case
+      Left exception -> throw exception
+      Right (fs::[funtype]) -> pure fs
 

--- a/deps/get-deps.sh
+++ b/deps/get-deps.sh
@@ -36,3 +36,23 @@ case "$(uname)" in
     ln -s libmklml_intel.so mklml/lib/libmklml.so
     ;;
 esac
+
+
+# Following codes are copied from pytorch/tools/run-clang-tidy-in-ci.sh.
+# Generate ATen files.
+pushd pytorch
+
+if [[ ! -d build ]]; then
+mkdir build
+fi
+
+python aten/src/ATen/gen.py \
+  -s aten/src/ATen \
+  -d build/aten/src/ATen \
+  aten/src/ATen/Declarations.cwrap \
+  aten/src/THNN/generic/THNN.h \
+  aten/src/THCUNN/generic/THCUNN.h \
+  aten/src/ATen/nn.yaml \
+  aten/src/ATen/native/native_functions.yaml
+
+popd

--- a/spec/Declarations.yaml
+++ b/spec/Declarations.yaml
@@ -1,0 +1,1 @@
+../deps/pytorch/build/aten/src/ATen/Declarations.yaml


### PR DESCRIPTION
It is difficult to parse nn.yaml and make codegen for the yaml.
We change the spec to make codes from nn.yaml to Declarations.yaml, though Declarations.yaml is not stable.(nn.yaml is not stable too.)