### PR TITLE
Support cpp-operator partially

### DIFF
--- a/codegen/src/RenderClass.hs
+++ b/codegen/src/RenderClass.hs
@@ -57,7 +57,7 @@ C.include "<vector>"
 |]
 
 renderConstructors :: Bool -> PC.CppClassSpec -> Text
-renderConstructors is_managed typ_ = mconcat $ map (methodToCpp typ_ True is_managed False "" "") (PC.constructors typ_)
+renderConstructors is_managed typ_ = mconcat $ map (methodToCpp typ_ True is_managed True "" "") (PC.constructors typ_)
 
 renderDestructor :: Bool -> PC.CppClassSpec -> Text
 renderDestructor is_managed typ_ = if is_managed then "" else [st|
@@ -70,7 +70,7 @@ instance CppObject #{PC.hsname typ_} where
 
 
 renderMethods :: Bool -> PC.CppClassSpec -> Text
-renderMethods is_managed typ_ = mconcat $ map (methodToCpp typ_ False is_managed False "" "") (PC.methods typ_)
+renderMethods is_managed typ_ = mconcat $ map (methodToCpp typ_ False is_managed True "" "") (PC.methods typ_)
 
 
 decodeAndCodeGen :: String -> String -> IO ()

--- a/codegen/src/RenderDeclarations.hs
+++ b/codegen/src/RenderDeclarations.hs
@@ -27,6 +27,7 @@ toFunction dl = P.Function
   , P.retType = case D.returns dl of
       [a] -> D.type2type a
       ax -> P.Tuple $ map D.type2type ax
+  , P.variant = P.VFunction
   }
 
 renderFunctions :: Bool -> Bool -> String -> [D.Declaration] -> Text

--- a/ffi/src/Aten/Managed/Type/IntArray.hs
+++ b/ffi/src/Aten/Managed/Type/IntArray.hs
@@ -50,15 +50,15 @@ intArray_size
   -> IO (CSize)
 intArray_size = cast1 Unmanaged.intArray_size
 
-intArray_at
+intArray_at_s
   :: ForeignPtr IntArray
   -> CSize
   -> IO (Int64)
-intArray_at = cast2 Unmanaged.intArray_at
+intArray_at_s = cast2 Unmanaged.intArray_at_s
 
-intArray_push_back
+intArray_push_back_l
   :: ForeignPtr IntArray
   -> Int64
   -> IO (())
-intArray_push_back = cast2 Unmanaged.intArray_push_back
+intArray_push_back_l = cast2 Unmanaged.intArray_push_back_l
 

--- a/ffi/src/Aten/Managed/Type/Scalar.hs
+++ b/ffi/src/Aten/Managed/Type/Scalar.hs
@@ -36,15 +36,15 @@ newScalar
   :: IO (ForeignPtr Scalar)
 newScalar = cast0 Unmanaged.newScalar
 
-newScalar_int
+newScalar_i
   :: CInt
   -> IO (ForeignPtr Scalar)
-newScalar_int = cast1 Unmanaged.newScalar_int
+newScalar_i = cast1 Unmanaged.newScalar_i
 
-newScalar_double
+newScalar_d
   :: CDouble
   -> IO (ForeignPtr Scalar)
-newScalar_double = cast1 Unmanaged.newScalar_double
+newScalar_d = cast1 Unmanaged.newScalar_d
 
 
 

--- a/ffi/src/Aten/Managed/Type/SparseTensorRef.hs
+++ b/ffi/src/Aten/Managed/Type/SparseTensorRef.hs
@@ -32,10 +32,10 @@ import qualified Aten.Unmanaged.Type.SparseTensorRef as Unmanaged
 
 
 
-newSparseTensorRef
+newSparseTensorRef_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr SparseTensorRef)
-newSparseTensorRef = cast1 Unmanaged.newSparseTensorRef
+newSparseTensorRef_t = cast1 Unmanaged.newSparseTensorRef_t
 
 
 

--- a/ffi/src/Aten/Managed/Type/Tensor.hs
+++ b/ffi/src/Aten/Managed/Type/Tensor.hs
@@ -36,10 +36,10 @@ newTensor
   :: IO (ForeignPtr Tensor)
 newTensor = cast0 Unmanaged.newTensor
 
-newTensor_Tensor
+newTensor_t
   :: ForeignPtr Tensor
   -> IO (ForeignPtr Tensor)
-newTensor_Tensor = cast1 Unmanaged.newTensor_Tensor
+newTensor_t = cast1 Unmanaged.newTensor_t
 
 
 
@@ -64,6 +64,12 @@ tensor_reset
   :: ForeignPtr Tensor
   -> IO (())
 tensor_reset = cast1 Unmanaged.tensor_reset
+
+tensor_is_same_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_same_t = cast2 Unmanaged.tensor_is_same_t
 
 tensor_use_count
   :: ForeignPtr Tensor
@@ -100,6 +106,30 @@ tensor_element_size
   -> IO (CSize)
 tensor_element_size = cast1 Unmanaged.tensor_element_size
 
+tensor_has_storage
+  :: ForeignPtr Tensor
+  -> IO (CBool)
+tensor_has_storage = cast1 Unmanaged.tensor_has_storage
+
+tensor_is_alias_of_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_alias_of_t = cast2 Unmanaged.tensor_is_alias_of_t
+
+tensor_copy__tb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_copy__tb = cast3 Unmanaged.tensor_copy__tb
+
+tensor_toType_s
+  :: ForeignPtr Tensor
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_toType_s = cast2 Unmanaged.tensor_toType_s
+
 tensor_is_variable
   :: ForeignPtr Tensor
   -> IO (CBool)
@@ -125,8 +155,2593 @@ tensor_is_sparse
   -> IO (CBool)
 tensor_is_sparse = cast1 Unmanaged.tensor_is_sparse
 
+tensor_options
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr TensorOptions)
+tensor_options = cast1 Unmanaged.tensor_options
+
 tensor_print
   :: ForeignPtr Tensor
   -> IO (())
 tensor_print = cast1 Unmanaged.tensor_print
+
+tensor__iadd__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (())
+tensor__iadd__t = cast2 Unmanaged.tensor__iadd__t
+
+tensor__iadd__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (())
+tensor__iadd__s = cast2 Unmanaged.tensor__iadd__s
+
+tensor__isub__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (())
+tensor__isub__t = cast2 Unmanaged.tensor__isub__t
+
+tensor__isub__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (())
+tensor__isub__s = cast2 Unmanaged.tensor__isub__s
+
+tensor__imul__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (())
+tensor__imul__t = cast2 Unmanaged.tensor__imul__t
+
+tensor__imul__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (())
+tensor__imul__s = cast2 Unmanaged.tensor__imul__s
+
+tensor__at__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor__at__s = cast2 Unmanaged.tensor__at__s
+
+tensor__at__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor__at__t = cast2 Unmanaged.tensor__at__t
+
+tensor__at__l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor__at__l = cast2 Unmanaged.tensor__at__l
+
+tensor_cpu
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_cpu = cast1 Unmanaged.tensor_cpu
+
+tensor_cuda
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_cuda = cast1 Unmanaged.tensor_cuda
+
+tensor_hip
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_hip = cast1 Unmanaged.tensor_hip
+
+tensor_set_requires_grad_b
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_set_requires_grad_b = cast2 Unmanaged.tensor_set_requires_grad_b
+
+tensor_requires_grad
+  :: ForeignPtr Tensor
+  -> IO (CBool)
+tensor_requires_grad = cast1 Unmanaged.tensor_requires_grad
+
+tensor_grad
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_grad = cast1 Unmanaged.tensor_grad
+
+tensor_set_data_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (())
+tensor_set_data_t = cast2 Unmanaged.tensor_set_data_t
+
+tensor_abs
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_abs = cast1 Unmanaged.tensor_abs
+
+tensor_abs_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_abs_ = cast1 Unmanaged.tensor_abs_
+
+tensor_acos
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_acos = cast1 Unmanaged.tensor_acos
+
+tensor_acos_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_acos_ = cast1 Unmanaged.tensor_acos_
+
+tensor_add_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_add_ts = cast3 Unmanaged.tensor_add_ts
+
+tensor_add__ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_add__ts = cast3 Unmanaged.tensor_add__ts
+
+tensor_add_ss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_add_ss = cast3 Unmanaged.tensor_add_ss
+
+tensor_add__ss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_add__ss = cast3 Unmanaged.tensor_add__ss
+
+tensor_addmv_ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addmv_ttss = cast5 Unmanaged.tensor_addmv_ttss
+
+tensor_addmv__ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addmv__ttss = cast5 Unmanaged.tensor_addmv__ttss
+
+tensor_addr_ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addr_ttss = cast5 Unmanaged.tensor_addr_ttss
+
+tensor_addr__ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addr__ttss = cast5 Unmanaged.tensor_addr__ttss
+
+tensor_all_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_all_lb = cast3 Unmanaged.tensor_all_lb
+
+tensor_allclose_tddb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> CDouble
+  -> CBool
+  -> IO (CBool)
+tensor_allclose_tddb = cast5 Unmanaged.tensor_allclose_tddb
+
+tensor_any_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_any_lb = cast3 Unmanaged.tensor_any_lb
+
+tensor_argmax_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_argmax_lb = cast3 Unmanaged.tensor_argmax_lb
+
+tensor_argmax
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_argmax = cast1 Unmanaged.tensor_argmax
+
+tensor_argmin_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_argmin_lb = cast3 Unmanaged.tensor_argmin_lb
+
+tensor_argmin
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_argmin = cast1 Unmanaged.tensor_argmin
+
+tensor_asin
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_asin = cast1 Unmanaged.tensor_asin
+
+tensor_asin_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_asin_ = cast1 Unmanaged.tensor_asin_
+
+tensor_atan
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_atan = cast1 Unmanaged.tensor_atan
+
+tensor_atan_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_atan_ = cast1 Unmanaged.tensor_atan_
+
+tensor_baddbmm_ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_baddbmm_ttss = cast5 Unmanaged.tensor_baddbmm_ttss
+
+tensor_baddbmm__ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_baddbmm__ttss = cast5 Unmanaged.tensor_baddbmm__ttss
+
+tensor_bernoulli_p
+  :: ForeignPtr Tensor
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_bernoulli_p = cast2 Unmanaged.tensor_bernoulli_p
+
+tensor_bernoulli__tp
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_bernoulli__tp = cast3 Unmanaged.tensor_bernoulli__tp
+
+tensor_bernoulli__dp
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_bernoulli__dp = cast3 Unmanaged.tensor_bernoulli__dp
+
+tensor_bernoulli_dp
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_bernoulli_dp = cast3 Unmanaged.tensor_bernoulli_dp
+
+tensor_bincount_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_bincount_tl = cast3 Unmanaged.tensor_bincount_tl
+
+tensor_bmm_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_bmm_t = cast2 Unmanaged.tensor_bmm_t
+
+tensor_ceil
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_ceil = cast1 Unmanaged.tensor_ceil
+
+tensor_ceil_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_ceil_ = cast1 Unmanaged.tensor_ceil_
+
+tensor_clamp_max_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_clamp_max_s = cast2 Unmanaged.tensor_clamp_max_s
+
+tensor_clamp_max__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_clamp_max__s = cast2 Unmanaged.tensor_clamp_max__s
+
+tensor_clamp_min_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_clamp_min_s = cast2 Unmanaged.tensor_clamp_min_s
+
+tensor_clamp_min__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_clamp_min__s = cast2 Unmanaged.tensor_clamp_min__s
+
+tensor_contiguous
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_contiguous = cast1 Unmanaged.tensor_contiguous
+
+tensor_cos
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_cos = cast1 Unmanaged.tensor_cos
+
+tensor_cos_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_cos_ = cast1 Unmanaged.tensor_cos_
+
+tensor_cosh
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_cosh = cast1 Unmanaged.tensor_cosh
+
+tensor_cosh_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_cosh_ = cast1 Unmanaged.tensor_cosh_
+
+tensor_cumsum_ls
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_cumsum_ls = cast3 Unmanaged.tensor_cumsum_ls
+
+tensor_cumsum_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_cumsum_l = cast2 Unmanaged.tensor_cumsum_l
+
+tensor_cumprod_ls
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_cumprod_ls = cast3 Unmanaged.tensor_cumprod_ls
+
+tensor_cumprod_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_cumprod_l = cast2 Unmanaged.tensor_cumprod_l
+
+tensor_det
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_det = cast1 Unmanaged.tensor_det
+
+tensor_diag_embed_lll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_diag_embed_lll = cast4 Unmanaged.tensor_diag_embed_lll
+
+tensor_diagflat_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_diagflat_l = cast2 Unmanaged.tensor_diagflat_l
+
+tensor_diagonal_lll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_diagonal_lll = cast4 Unmanaged.tensor_diagonal_lll
+
+tensor_div_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_div_t = cast2 Unmanaged.tensor_div_t
+
+tensor_div__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_div__t = cast2 Unmanaged.tensor_div__t
+
+tensor_div_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_div_s = cast2 Unmanaged.tensor_div_s
+
+tensor_div__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_div__s = cast2 Unmanaged.tensor_div__s
+
+tensor_dot_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_dot_t = cast2 Unmanaged.tensor_dot_t
+
+tensor_resize__l
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_resize__l = cast2 Unmanaged.tensor_resize__l
+
+tensor_erf
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_erf = cast1 Unmanaged.tensor_erf
+
+tensor_erf_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_erf_ = cast1 Unmanaged.tensor_erf_
+
+tensor_erfc
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_erfc = cast1 Unmanaged.tensor_erfc
+
+tensor_erfc_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_erfc_ = cast1 Unmanaged.tensor_erfc_
+
+tensor_exp
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_exp = cast1 Unmanaged.tensor_exp
+
+tensor_exp_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_exp_ = cast1 Unmanaged.tensor_exp_
+
+tensor_expm1
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_expm1 = cast1 Unmanaged.tensor_expm1
+
+tensor_expm1_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_expm1_ = cast1 Unmanaged.tensor_expm1_
+
+tensor_expand_lb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_expand_lb = cast3 Unmanaged.tensor_expand_lb
+
+tensor_expand_as_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_expand_as_t = cast2 Unmanaged.tensor_expand_as_t
+
+tensor_flatten_ll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_flatten_ll = cast3 Unmanaged.tensor_flatten_ll
+
+tensor_fill__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_fill__s = cast2 Unmanaged.tensor_fill__s
+
+tensor_fill__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_fill__t = cast2 Unmanaged.tensor_fill__t
+
+tensor_floor
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_floor = cast1 Unmanaged.tensor_floor
+
+tensor_floor_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_floor_ = cast1 Unmanaged.tensor_floor_
+
+tensor_ger_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_ger_t = cast2 Unmanaged.tensor_ger_t
+
+tensor_fft_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_fft_lb = cast3 Unmanaged.tensor_fft_lb
+
+tensor_ifft_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_ifft_lb = cast3 Unmanaged.tensor_ifft_lb
+
+tensor_rfft_lbb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_rfft_lbb = cast4 Unmanaged.tensor_rfft_lbb
+
+tensor_irfft_lbbl
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> CBool
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_irfft_lbbl = cast5 Unmanaged.tensor_irfft_lbbl
+
+tensor_index_l
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorList
+  -> IO (ForeignPtr Tensor)
+tensor_index_l = cast2 Unmanaged.tensor_index_l
+
+tensor_index_copy__ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_index_copy__ltt = cast4 Unmanaged.tensor_index_copy__ltt
+
+tensor_index_copy_ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_index_copy_ltt = cast4 Unmanaged.tensor_index_copy_ltt
+
+tensor_index_put__ltb
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorList
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_index_put__ltb = cast4 Unmanaged.tensor_index_put__ltb
+
+tensor_index_put_ltb
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorList
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_index_put_ltb = cast4 Unmanaged.tensor_index_put_ltb
+
+tensor_inverse
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_inverse = cast1 Unmanaged.tensor_inverse
+
+tensor_isclose_tddb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CDouble
+  -> CDouble
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_isclose_tddb = cast5 Unmanaged.tensor_isclose_tddb
+
+tensor_is_distributed
+  :: ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_distributed = cast1 Unmanaged.tensor_is_distributed
+
+tensor_is_floating_point
+  :: ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_floating_point = cast1 Unmanaged.tensor_is_floating_point
+
+tensor_is_complex
+  :: ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_complex = cast1 Unmanaged.tensor_is_complex
+
+tensor_is_nonzero
+  :: ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_nonzero = cast1 Unmanaged.tensor_is_nonzero
+
+tensor_is_same_size_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_same_size_t = cast2 Unmanaged.tensor_is_same_size_t
+
+tensor_is_signed
+  :: ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_signed = cast1 Unmanaged.tensor_is_signed
+
+tensor_kthvalue_llb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_kthvalue_llb = cast4 Unmanaged.tensor_kthvalue_llb
+
+tensor_log
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_log = cast1 Unmanaged.tensor_log
+
+tensor_log_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_log_ = cast1 Unmanaged.tensor_log_
+
+tensor_log10
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_log10 = cast1 Unmanaged.tensor_log10
+
+tensor_log10_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_log10_ = cast1 Unmanaged.tensor_log10_
+
+tensor_log1p
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_log1p = cast1 Unmanaged.tensor_log1p
+
+tensor_log1p_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_log1p_ = cast1 Unmanaged.tensor_log1p_
+
+tensor_log2
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_log2 = cast1 Unmanaged.tensor_log2
+
+tensor_log2_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_log2_ = cast1 Unmanaged.tensor_log2_
+
+tensor_logdet
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_logdet = cast1 Unmanaged.tensor_logdet
+
+tensor_log_softmax_ls
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_log_softmax_ls = cast3 Unmanaged.tensor_log_softmax_ls
+
+tensor_log_softmax_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_log_softmax_l = cast2 Unmanaged.tensor_log_softmax_l
+
+tensor_logsumexp_lb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_logsumexp_lb = cast3 Unmanaged.tensor_logsumexp_lb
+
+tensor_matmul_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_matmul_t = cast2 Unmanaged.tensor_matmul_t
+
+tensor_matrix_power_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_matrix_power_l = cast2 Unmanaged.tensor_matrix_power_l
+
+tensor_max_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_max_lb = cast3 Unmanaged.tensor_max_lb
+
+tensor_max_values_lb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_max_values_lb = cast3 Unmanaged.tensor_max_values_lb
+
+tensor_mean_s
+  :: ForeignPtr Tensor
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_mean_s = cast2 Unmanaged.tensor_mean_s
+
+tensor_mean
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_mean = cast1 Unmanaged.tensor_mean
+
+tensor_mean_lbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_mean_lbs = cast4 Unmanaged.tensor_mean_lbs
+
+tensor_mean_lb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_mean_lb = cast3 Unmanaged.tensor_mean_lb
+
+tensor_mean_ls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_mean_ls = cast3 Unmanaged.tensor_mean_ls
+
+tensor_median_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_median_lb = cast3 Unmanaged.tensor_median_lb
+
+tensor_min_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_min_lb = cast3 Unmanaged.tensor_min_lb
+
+tensor_min_values_lb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_min_values_lb = cast3 Unmanaged.tensor_min_values_lb
+
+tensor_mm_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_mm_t = cast2 Unmanaged.tensor_mm_t
+
+tensor_mode_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_mode_lb = cast3 Unmanaged.tensor_mode_lb
+
+tensor_mul_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_mul_t = cast2 Unmanaged.tensor_mul_t
+
+tensor_mul__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_mul__t = cast2 Unmanaged.tensor_mul__t
+
+tensor_mul_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_mul_s = cast2 Unmanaged.tensor_mul_s
+
+tensor_mul__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_mul__s = cast2 Unmanaged.tensor_mul__s
+
+tensor_mv_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_mv_t = cast2 Unmanaged.tensor_mv_t
+
+tensor_mvlgamma_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_mvlgamma_l = cast2 Unmanaged.tensor_mvlgamma_l
+
+tensor_mvlgamma__l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_mvlgamma__l = cast2 Unmanaged.tensor_mvlgamma__l
+
+tensor_narrow_copy_lll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_narrow_copy_lll = cast4 Unmanaged.tensor_narrow_copy_lll
+
+tensor_narrow_lll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_narrow_lll = cast4 Unmanaged.tensor_narrow_lll
+
+tensor_permute_l
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_permute_l = cast2 Unmanaged.tensor_permute_l
+
+tensor_pin_memory
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_pin_memory = cast1 Unmanaged.tensor_pin_memory
+
+tensor_pinverse_d
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> IO (ForeignPtr Tensor)
+tensor_pinverse_d = cast2 Unmanaged.tensor_pinverse_d
+
+tensor_repeat_l
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_repeat_l = cast2 Unmanaged.tensor_repeat_l
+
+tensor_reshape_l
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_reshape_l = cast2 Unmanaged.tensor_reshape_l
+
+tensor_reshape_as_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_reshape_as_t = cast2 Unmanaged.tensor_reshape_as_t
+
+tensor_round
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_round = cast1 Unmanaged.tensor_round
+
+tensor_round_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_round_ = cast1 Unmanaged.tensor_round_
+
+tensor_relu
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_relu = cast1 Unmanaged.tensor_relu
+
+tensor_relu_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_relu_ = cast1 Unmanaged.tensor_relu_
+
+tensor_prelu_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_prelu_t = cast2 Unmanaged.tensor_prelu_t
+
+tensor_prelu_backward_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_prelu_backward_tt = cast3 Unmanaged.tensor_prelu_backward_tt
+
+tensor_hardshrink_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_hardshrink_s = cast2 Unmanaged.tensor_hardshrink_s
+
+tensor_hardshrink_backward_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_hardshrink_backward_ts = cast3 Unmanaged.tensor_hardshrink_backward_ts
+
+tensor_rsqrt
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_rsqrt = cast1 Unmanaged.tensor_rsqrt
+
+tensor_rsqrt_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_rsqrt_ = cast1 Unmanaged.tensor_rsqrt_
+
+tensor_select_ll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_select_ll = cast3 Unmanaged.tensor_select_ll
+
+tensor_sigmoid
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sigmoid = cast1 Unmanaged.tensor_sigmoid
+
+tensor_sigmoid_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sigmoid_ = cast1 Unmanaged.tensor_sigmoid_
+
+tensor_sin
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sin = cast1 Unmanaged.tensor_sin
+
+tensor_sin_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sin_ = cast1 Unmanaged.tensor_sin_
+
+tensor_sinh
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sinh = cast1 Unmanaged.tensor_sinh
+
+tensor_sinh_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sinh_ = cast1 Unmanaged.tensor_sinh_
+
+tensor_detach
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_detach = cast1 Unmanaged.tensor_detach
+
+tensor_detach_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_detach_ = cast1 Unmanaged.tensor_detach_
+
+tensor_size_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (Int64)
+tensor_size_l = cast2 Unmanaged.tensor_size_l
+
+tensor_slice_llll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_slice_llll = cast5 Unmanaged.tensor_slice_llll
+
+tensor_slogdet
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_slogdet = cast1 Unmanaged.tensor_slogdet
+
+tensor_smm_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_smm_t = cast2 Unmanaged.tensor_smm_t
+
+tensor_softmax_ls
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_softmax_ls = cast3 Unmanaged.tensor_softmax_ls
+
+tensor_softmax_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_softmax_l = cast2 Unmanaged.tensor_softmax_l
+
+tensor_squeeze
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_squeeze = cast1 Unmanaged.tensor_squeeze
+
+tensor_squeeze_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_squeeze_l = cast2 Unmanaged.tensor_squeeze_l
+
+tensor_squeeze_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_squeeze_ = cast1 Unmanaged.tensor_squeeze_
+
+tensor_squeeze__l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_squeeze__l = cast2 Unmanaged.tensor_squeeze__l
+
+tensor_sspaddmm_ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_sspaddmm_ttss = cast5 Unmanaged.tensor_sspaddmm_ttss
+
+tensor_stride_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (Int64)
+tensor_stride_l = cast2 Unmanaged.tensor_stride_l
+
+tensor_sum_s
+  :: ForeignPtr Tensor
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_sum_s = cast2 Unmanaged.tensor_sum_s
+
+tensor_sum
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sum = cast1 Unmanaged.tensor_sum
+
+tensor_sum_lbs
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_sum_lbs = cast4 Unmanaged.tensor_sum_lbs
+
+tensor_sum_lb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_sum_lb = cast3 Unmanaged.tensor_sum_lb
+
+tensor_sum_ls
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_sum_ls = cast3 Unmanaged.tensor_sum_ls
+
+tensor_sum_to_size_l
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_sum_to_size_l = cast2 Unmanaged.tensor_sum_to_size_l
+
+tensor_sqrt
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sqrt = cast1 Unmanaged.tensor_sqrt
+
+tensor_sqrt_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sqrt_ = cast1 Unmanaged.tensor_sqrt_
+
+tensor_std_b
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_std_b = cast2 Unmanaged.tensor_std_b
+
+tensor_std_lbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_std_lbb = cast4 Unmanaged.tensor_std_lbb
+
+tensor_prod_s
+  :: ForeignPtr Tensor
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_prod_s = cast2 Unmanaged.tensor_prod_s
+
+tensor_prod
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_prod = cast1 Unmanaged.tensor_prod
+
+tensor_prod_lbs
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_prod_lbs = cast4 Unmanaged.tensor_prod_lbs
+
+tensor_prod_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_prod_lb = cast3 Unmanaged.tensor_prod_lb
+
+tensor_prod_ls
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (ForeignPtr Tensor)
+tensor_prod_ls = cast3 Unmanaged.tensor_prod_ls
+
+tensor_t
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_t = cast1 Unmanaged.tensor_t
+
+tensor_t_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_t_ = cast1 Unmanaged.tensor_t_
+
+tensor_tan
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_tan = cast1 Unmanaged.tensor_tan
+
+tensor_tan_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_tan_ = cast1 Unmanaged.tensor_tan_
+
+tensor_tanh
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_tanh = cast1 Unmanaged.tensor_tanh
+
+tensor_tanh_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_tanh_ = cast1 Unmanaged.tensor_tanh_
+
+tensor_transpose_ll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_transpose_ll = cast3 Unmanaged.tensor_transpose_ll
+
+tensor_transpose__ll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_transpose__ll = cast3 Unmanaged.tensor_transpose__ll
+
+tensor_flip_l
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_flip_l = cast2 Unmanaged.tensor_flip_l
+
+tensor_roll_ll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_roll_ll = cast3 Unmanaged.tensor_roll_ll
+
+tensor_rot90_ll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_rot90_ll = cast3 Unmanaged.tensor_rot90_ll
+
+tensor_trunc
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_trunc = cast1 Unmanaged.tensor_trunc
+
+tensor_trunc_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_trunc_ = cast1 Unmanaged.tensor_trunc_
+
+tensor_type_as_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_type_as_t = cast2 Unmanaged.tensor_type_as_t
+
+tensor_unsqueeze_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_unsqueeze_l = cast2 Unmanaged.tensor_unsqueeze_l
+
+tensor_unsqueeze__l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_unsqueeze__l = cast2 Unmanaged.tensor_unsqueeze__l
+
+tensor_var_b
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_var_b = cast2 Unmanaged.tensor_var_b
+
+tensor_var_lbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_var_lbb = cast4 Unmanaged.tensor_var_lbb
+
+tensor_view_as_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_view_as_t = cast2 Unmanaged.tensor_view_as_t
+
+tensor_where_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_where_tt = cast3 Unmanaged.tensor_where_tt
+
+tensor_norm_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_norm_s = cast2 Unmanaged.tensor_norm_s
+
+tensor_clone
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_clone = cast1 Unmanaged.tensor_clone
+
+tensor_resize_as__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_resize_as__t = cast2 Unmanaged.tensor_resize_as__t
+
+tensor_pow_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_pow_s = cast2 Unmanaged.tensor_pow_s
+
+tensor_zero_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_zero_ = cast1 Unmanaged.tensor_zero_
+
+tensor_sub_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_sub_ts = cast3 Unmanaged.tensor_sub_ts
+
+tensor_sub__ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_sub__ts = cast3 Unmanaged.tensor_sub__ts
+
+tensor_sub_ss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_sub_ss = cast3 Unmanaged.tensor_sub_ss
+
+tensor_sub__ss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_sub__ss = cast3 Unmanaged.tensor_sub__ss
+
+tensor_addmm_ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addmm_ttss = cast5 Unmanaged.tensor_addmm_ttss
+
+tensor_addmm__ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addmm__ttss = cast5 Unmanaged.tensor_addmm__ttss
+
+tensor_sparse_resize__lll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_sparse_resize__lll = cast4 Unmanaged.tensor_sparse_resize__lll
+
+tensor_sparse_resize_and_clear__lll
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_sparse_resize_and_clear__lll = cast4 Unmanaged.tensor_sparse_resize_and_clear__lll
+
+tensor_sparse_mask_r
+  :: ForeignPtr Tensor
+  -> ForeignPtr SparseTensorRef
+  -> IO (ForeignPtr Tensor)
+tensor_sparse_mask_r = cast2 Unmanaged.tensor_sparse_mask_r
+
+tensor_to_dense
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_to_dense = cast1 Unmanaged.tensor_to_dense
+
+tensor_sparse_dim
+  :: ForeignPtr Tensor
+  -> IO (Int64)
+tensor_sparse_dim = cast1 Unmanaged.tensor_sparse_dim
+
+tensor__dimI
+  :: ForeignPtr Tensor
+  -> IO (Int64)
+tensor__dimI = cast1 Unmanaged.tensor__dimI
+
+tensor_dense_dim
+  :: ForeignPtr Tensor
+  -> IO (Int64)
+tensor_dense_dim = cast1 Unmanaged.tensor_dense_dim
+
+tensor__dimV
+  :: ForeignPtr Tensor
+  -> IO (Int64)
+tensor__dimV = cast1 Unmanaged.tensor__dimV
+
+tensor__nnz
+  :: ForeignPtr Tensor
+  -> IO (Int64)
+tensor__nnz = cast1 Unmanaged.tensor__nnz
+
+tensor_coalesce
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_coalesce = cast1 Unmanaged.tensor_coalesce
+
+tensor_is_coalesced
+  :: ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_coalesced = cast1 Unmanaged.tensor_is_coalesced
+
+tensor__indices
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor__indices = cast1 Unmanaged.tensor__indices
+
+tensor__values
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor__values = cast1 Unmanaged.tensor__values
+
+tensor__coalesced__b
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor__coalesced__b = cast2 Unmanaged.tensor__coalesced__b
+
+tensor_indices
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_indices = cast1 Unmanaged.tensor_indices
+
+tensor_values
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_values = cast1 Unmanaged.tensor_values
+
+tensor_numel
+  :: ForeignPtr Tensor
+  -> IO (Int64)
+tensor_numel = cast1 Unmanaged.tensor_numel
+
+tensor_to_sparse_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_to_sparse_l = cast2 Unmanaged.tensor_to_sparse_l
+
+tensor_to_sparse
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_to_sparse = cast1 Unmanaged.tensor_to_sparse
+
+tensor_to_obb
+  :: ForeignPtr Tensor
+  -> ForeignPtr TensorOptions
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_to_obb = cast4 Unmanaged.tensor_to_obb
+
+tensor_to_Dsbb
+  :: ForeignPtr Tensor
+  -> DeviceType
+  -> ScalarType
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_to_Dsbb = cast5 Unmanaged.tensor_to_Dsbb
+
+tensor_to_sbb
+  :: ForeignPtr Tensor
+  -> ScalarType
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_to_sbb = cast4 Unmanaged.tensor_to_sbb
+
+tensor_to_tbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_to_tbb = cast4 Unmanaged.tensor_to_tbb
+
+tensor_item
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Scalar)
+tensor_item = cast1 Unmanaged.tensor_item
+
+tensor_data_ptr
+  :: ForeignPtr Tensor
+  -> IO (Ptr ())
+tensor_data_ptr = cast1 Unmanaged.tensor_data_ptr
+
+tensor_set__S
+  :: ForeignPtr Tensor
+  -> ForeignPtr Storage
+  -> IO (ForeignPtr Tensor)
+tensor_set__S = cast2 Unmanaged.tensor_set__S
+
+tensor_set__Slll
+  :: ForeignPtr Tensor
+  -> ForeignPtr Storage
+  -> Int64
+  -> ForeignPtr IntArray
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_set__Slll = cast5 Unmanaged.tensor_set__Slll
+
+tensor_set__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_set__t = cast2 Unmanaged.tensor_set__t
+
+tensor_set_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_set_ = cast1 Unmanaged.tensor_set_
+
+tensor_is_set_to_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (CBool)
+tensor_is_set_to_t = cast2 Unmanaged.tensor_is_set_to_t
+
+tensor_masked_fill__ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_masked_fill__ts = cast3 Unmanaged.tensor_masked_fill__ts
+
+tensor_masked_fill_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_masked_fill_ts = cast3 Unmanaged.tensor_masked_fill_ts
+
+tensor_masked_fill__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_masked_fill__tt = cast3 Unmanaged.tensor_masked_fill__tt
+
+tensor_masked_fill_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_masked_fill_tt = cast3 Unmanaged.tensor_masked_fill_tt
+
+tensor_masked_scatter__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_masked_scatter__tt = cast3 Unmanaged.tensor_masked_scatter__tt
+
+tensor_masked_scatter_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_masked_scatter_tt = cast3 Unmanaged.tensor_masked_scatter_tt
+
+tensor_view_l
+  :: ForeignPtr Tensor
+  -> ForeignPtr IntArray
+  -> IO (ForeignPtr Tensor)
+tensor_view_l = cast2 Unmanaged.tensor_view_l
+
+tensor_put__ttb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_put__ttb = cast4 Unmanaged.tensor_put__ttb
+
+tensor_index_add__ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_index_add__ltt = cast4 Unmanaged.tensor_index_add__ltt
+
+tensor_index_add_ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_index_add_ltt = cast4 Unmanaged.tensor_index_add_ltt
+
+tensor_index_fill__lts
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_index_fill__lts = cast4 Unmanaged.tensor_index_fill__lts
+
+tensor_index_fill_lts
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_index_fill_lts = cast4 Unmanaged.tensor_index_fill_lts
+
+tensor_index_fill__ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_index_fill__ltt = cast4 Unmanaged.tensor_index_fill__ltt
+
+tensor_index_fill_ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_index_fill_ltt = cast4 Unmanaged.tensor_index_fill_ltt
+
+tensor_scatter__ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_scatter__ltt = cast4 Unmanaged.tensor_scatter__ltt
+
+tensor_scatter_ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_scatter_ltt = cast4 Unmanaged.tensor_scatter_ltt
+
+tensor_scatter__lts
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_scatter__lts = cast4 Unmanaged.tensor_scatter__lts
+
+tensor_scatter_lts
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_scatter_lts = cast4 Unmanaged.tensor_scatter_lts
+
+tensor_scatter_add__ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_scatter_add__ltt = cast4 Unmanaged.tensor_scatter_add__ltt
+
+tensor_scatter_add_ltt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_scatter_add_ltt = cast4 Unmanaged.tensor_scatter_add_ltt
+
+tensor_lt__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_lt__s = cast2 Unmanaged.tensor_lt__s
+
+tensor_lt__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_lt__t = cast2 Unmanaged.tensor_lt__t
+
+tensor_gt__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_gt__s = cast2 Unmanaged.tensor_gt__s
+
+tensor_gt__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_gt__t = cast2 Unmanaged.tensor_gt__t
+
+tensor_le__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_le__s = cast2 Unmanaged.tensor_le__s
+
+tensor_le__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_le__t = cast2 Unmanaged.tensor_le__t
+
+tensor_ge__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_ge__s = cast2 Unmanaged.tensor_ge__s
+
+tensor_ge__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_ge__t = cast2 Unmanaged.tensor_ge__t
+
+tensor_eq__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_eq__s = cast2 Unmanaged.tensor_eq__s
+
+tensor_eq__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_eq__t = cast2 Unmanaged.tensor_eq__t
+
+tensor_ne__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_ne__s = cast2 Unmanaged.tensor_ne__s
+
+tensor_ne__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_ne__t = cast2 Unmanaged.tensor_ne__t
+
+tensor___and___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___and___s = cast2 Unmanaged.tensor___and___s
+
+tensor___and___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___and___t = cast2 Unmanaged.tensor___and___t
+
+tensor___iand___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___iand___s = cast2 Unmanaged.tensor___iand___s
+
+tensor___iand___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___iand___t = cast2 Unmanaged.tensor___iand___t
+
+tensor___or___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___or___s = cast2 Unmanaged.tensor___or___s
+
+tensor___or___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___or___t = cast2 Unmanaged.tensor___or___t
+
+tensor___ior___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___ior___s = cast2 Unmanaged.tensor___ior___s
+
+tensor___ior___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___ior___t = cast2 Unmanaged.tensor___ior___t
+
+tensor___xor___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___xor___s = cast2 Unmanaged.tensor___xor___s
+
+tensor___xor___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___xor___t = cast2 Unmanaged.tensor___xor___t
+
+tensor___ixor___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___ixor___s = cast2 Unmanaged.tensor___ixor___s
+
+tensor___ixor___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___ixor___t = cast2 Unmanaged.tensor___ixor___t
+
+tensor___lshift___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___lshift___s = cast2 Unmanaged.tensor___lshift___s
+
+tensor___lshift___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___lshift___t = cast2 Unmanaged.tensor___lshift___t
+
+tensor___ilshift___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___ilshift___s = cast2 Unmanaged.tensor___ilshift___s
+
+tensor___ilshift___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___ilshift___t = cast2 Unmanaged.tensor___ilshift___t
+
+tensor___rshift___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___rshift___s = cast2 Unmanaged.tensor___rshift___s
+
+tensor___rshift___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___rshift___t = cast2 Unmanaged.tensor___rshift___t
+
+tensor___irshift___s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor___irshift___s = cast2 Unmanaged.tensor___irshift___s
+
+tensor___irshift___t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor___irshift___t = cast2 Unmanaged.tensor___irshift___t
+
+tensor_lgamma_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_lgamma_ = cast1 Unmanaged.tensor_lgamma_
+
+tensor_atan2__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_atan2__t = cast2 Unmanaged.tensor_atan2__t
+
+tensor_tril__l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_tril__l = cast2 Unmanaged.tensor_tril__l
+
+tensor_triu__l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_triu__l = cast2 Unmanaged.tensor_triu__l
+
+tensor_digamma_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_digamma_ = cast1 Unmanaged.tensor_digamma_
+
+tensor_polygamma__l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_polygamma__l = cast2 Unmanaged.tensor_polygamma__l
+
+tensor_erfinv_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_erfinv_ = cast1 Unmanaged.tensor_erfinv_
+
+tensor_frac_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_frac_ = cast1 Unmanaged.tensor_frac_
+
+tensor_renorm__sls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> Int64
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_renorm__sls = cast4 Unmanaged.tensor_renorm__sls
+
+tensor_reciprocal_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_reciprocal_ = cast1 Unmanaged.tensor_reciprocal_
+
+tensor_neg_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_neg_ = cast1 Unmanaged.tensor_neg_
+
+tensor_pow__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_pow__s = cast2 Unmanaged.tensor_pow__s
+
+tensor_pow__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_pow__t = cast2 Unmanaged.tensor_pow__t
+
+tensor_lerp__ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_lerp__ts = cast3 Unmanaged.tensor_lerp__ts
+
+tensor_lerp__tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_lerp__tt = cast3 Unmanaged.tensor_lerp__tt
+
+tensor_sign_
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sign_ = cast1 Unmanaged.tensor_sign_
+
+tensor_fmod__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_fmod__s = cast2 Unmanaged.tensor_fmod__s
+
+tensor_fmod__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_fmod__t = cast2 Unmanaged.tensor_fmod__t
+
+tensor_remainder__s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_remainder__s = cast2 Unmanaged.tensor_remainder__s
+
+tensor_remainder__t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_remainder__t = cast2 Unmanaged.tensor_remainder__t
+
+tensor_addbmm__ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addbmm__ttss = cast5 Unmanaged.tensor_addbmm__ttss
+
+tensor_addbmm_ttss
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addbmm_ttss = cast5 Unmanaged.tensor_addbmm_ttss
+
+tensor_addcmul__tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addcmul__tts = cast4 Unmanaged.tensor_addcmul__tts
+
+tensor_addcdiv__tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addcdiv__tts = cast4 Unmanaged.tensor_addcdiv__tts
+
+tensor_random__llp
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_random__llp = cast4 Unmanaged.tensor_random__llp
+
+tensor_random__lp
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_random__lp = cast3 Unmanaged.tensor_random__lp
+
+tensor_random__p
+  :: ForeignPtr Tensor
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_random__p = cast2 Unmanaged.tensor_random__p
+
+tensor_uniform__ddp
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> CDouble
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_uniform__ddp = cast4 Unmanaged.tensor_uniform__ddp
+
+tensor_normal__ddp
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> CDouble
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_normal__ddp = cast4 Unmanaged.tensor_normal__ddp
+
+tensor_cauchy__ddp
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> CDouble
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_cauchy__ddp = cast4 Unmanaged.tensor_cauchy__ddp
+
+tensor_log_normal__ddp
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> CDouble
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_log_normal__ddp = cast4 Unmanaged.tensor_log_normal__ddp
+
+tensor_exponential__dp
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_exponential__dp = cast3 Unmanaged.tensor_exponential__dp
+
+tensor_geometric__dp
+  :: ForeignPtr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_geometric__dp = cast3 Unmanaged.tensor_geometric__dp
+
+tensor_diag_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_diag_l = cast2 Unmanaged.tensor_diag_l
+
+tensor_cross_tl
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_cross_tl = cast3 Unmanaged.tensor_cross_tl
+
+tensor_triu_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_triu_l = cast2 Unmanaged.tensor_triu_l
+
+tensor_tril_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_tril_l = cast2 Unmanaged.tensor_tril_l
+
+tensor_trace
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_trace = cast1 Unmanaged.tensor_trace
+
+tensor_ne_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_ne_s = cast2 Unmanaged.tensor_ne_s
+
+tensor_ne_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_ne_t = cast2 Unmanaged.tensor_ne_t
+
+tensor_eq_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_eq_s = cast2 Unmanaged.tensor_eq_s
+
+tensor_eq_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_eq_t = cast2 Unmanaged.tensor_eq_t
+
+tensor_ge_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_ge_s = cast2 Unmanaged.tensor_ge_s
+
+tensor_ge_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_ge_t = cast2 Unmanaged.tensor_ge_t
+
+tensor_le_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_le_s = cast2 Unmanaged.tensor_le_s
+
+tensor_le_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_le_t = cast2 Unmanaged.tensor_le_t
+
+tensor_gt_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_gt_s = cast2 Unmanaged.tensor_gt_s
+
+tensor_gt_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_gt_t = cast2 Unmanaged.tensor_gt_t
+
+tensor_lt_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_lt_s = cast2 Unmanaged.tensor_lt_s
+
+tensor_lt_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_lt_t = cast2 Unmanaged.tensor_lt_t
+
+tensor_take_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_take_t = cast2 Unmanaged.tensor_take_t
+
+tensor_index_select_lt
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_index_select_lt = cast3 Unmanaged.tensor_index_select_lt
+
+tensor_masked_select_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_masked_select_t = cast2 Unmanaged.tensor_masked_select_t
+
+tensor_nonzero
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_nonzero = cast1 Unmanaged.tensor_nonzero
+
+tensor_gather_ltb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_gather_ltb = cast4 Unmanaged.tensor_gather_ltb
+
+tensor_addcmul_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addcmul_tts = cast4 Unmanaged.tensor_addcmul_tts
+
+tensor_addcdiv_tts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_addcdiv_tts = cast4 Unmanaged.tensor_addcdiv_tts
+
+tensor_gels_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_gels_t = cast2 Unmanaged.tensor_gels_t
+
+tensor_trtrs_tbbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_trtrs_tbbb = cast5 Unmanaged.tensor_trtrs_tbbb
+
+tensor_symeig_bb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_symeig_bb = cast3 Unmanaged.tensor_symeig_bb
+
+tensor_eig_b
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_eig_b = cast2 Unmanaged.tensor_eig_b
+
+tensor_svd_bb
+  :: ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor,Tensor))
+tensor_svd_bb = cast3 Unmanaged.tensor_svd_bb
+
+tensor_cholesky_b
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_cholesky_b = cast2 Unmanaged.tensor_cholesky_b
+
+tensor_cholesky_solve_tb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_cholesky_solve_tb = cast3 Unmanaged.tensor_cholesky_solve_tb
+
+tensor_solve_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_solve_t = cast2 Unmanaged.tensor_solve_t
+
+tensor_potri_b
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_potri_b = cast2 Unmanaged.tensor_potri_b
+
+tensor_pstrf_bs
+  :: ForeignPtr Tensor
+  -> CBool
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_pstrf_bs = cast3 Unmanaged.tensor_pstrf_bs
+
+tensor_qr
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_qr = cast1 Unmanaged.tensor_qr
+
+tensor_geqrf
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_geqrf = cast1 Unmanaged.tensor_geqrf
+
+tensor_orgqr_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_orgqr_t = cast2 Unmanaged.tensor_orgqr_t
+
+tensor_ormqr_ttbb
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_ormqr_ttbb = cast5 Unmanaged.tensor_ormqr_ttbb
+
+tensor_btrifact_b
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_btrifact_b = cast2 Unmanaged.tensor_btrifact_b
+
+tensor_btrifact_with_info_b
+  :: ForeignPtr Tensor
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor,Tensor))
+tensor_btrifact_with_info_b = cast2 Unmanaged.tensor_btrifact_with_info_b
+
+tensor_btrisolve_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_btrisolve_tt = cast3 Unmanaged.tensor_btrisolve_tt
+
+tensor_multinomial_lbp
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> Ptr Generator
+  -> IO (ForeignPtr Tensor)
+tensor_multinomial_lbp = cast4 Unmanaged.tensor_multinomial_lbp
+
+tensor_lgamma
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_lgamma = cast1 Unmanaged.tensor_lgamma
+
+tensor_digamma
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_digamma = cast1 Unmanaged.tensor_digamma
+
+tensor_polygamma_l
+  :: ForeignPtr Tensor
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_polygamma_l = cast2 Unmanaged.tensor_polygamma_l
+
+tensor_erfinv
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_erfinv = cast1 Unmanaged.tensor_erfinv
+
+tensor_frac
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_frac = cast1 Unmanaged.tensor_frac
+
+tensor_dist_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_dist_ts = cast3 Unmanaged.tensor_dist_ts
+
+tensor_reciprocal
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_reciprocal = cast1 Unmanaged.tensor_reciprocal
+
+tensor_neg
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_neg = cast1 Unmanaged.tensor_neg
+
+tensor_atan2_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_atan2_t = cast2 Unmanaged.tensor_atan2_t
+
+tensor_lerp_ts
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_lerp_ts = cast3 Unmanaged.tensor_lerp_ts
+
+tensor_lerp_tt
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_lerp_tt = cast3 Unmanaged.tensor_lerp_tt
+
+tensor_histc_lss
+  :: ForeignPtr Tensor
+  -> Int64
+  -> ForeignPtr Scalar
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_histc_lss = cast4 Unmanaged.tensor_histc_lss
+
+tensor_sign
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_sign = cast1 Unmanaged.tensor_sign
+
+tensor_fmod_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_fmod_s = cast2 Unmanaged.tensor_fmod_s
+
+tensor_fmod_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_fmod_t = cast2 Unmanaged.tensor_fmod_t
+
+tensor_remainder_s
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_remainder_s = cast2 Unmanaged.tensor_remainder_s
+
+tensor_remainder_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_remainder_t = cast2 Unmanaged.tensor_remainder_t
+
+tensor_min_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_min_t = cast2 Unmanaged.tensor_min_t
+
+tensor_min
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_min = cast1 Unmanaged.tensor_min
+
+tensor_max_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_max_t = cast2 Unmanaged.tensor_max_t
+
+tensor_max
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_max = cast1 Unmanaged.tensor_max
+
+tensor_median
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_median = cast1 Unmanaged.tensor_median
+
+tensor_sort_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_sort_lb = cast3 Unmanaged.tensor_sort_lb
+
+tensor_argsort_lb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> CBool
+  -> IO (ForeignPtr Tensor)
+tensor_argsort_lb = cast3 Unmanaged.tensor_argsort_lb
+
+tensor_topk_llbb
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> CBool
+  -> CBool
+  -> IO (ForeignPtr (Tensor,Tensor))
+tensor_topk_llbb = cast5 Unmanaged.tensor_topk_llbb
+
+tensor_all
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_all = cast1 Unmanaged.tensor_all
+
+tensor_any
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_any = cast1 Unmanaged.tensor_any
+
+tensor_renorm_sls
+  :: ForeignPtr Tensor
+  -> ForeignPtr Scalar
+  -> Int64
+  -> ForeignPtr Scalar
+  -> IO (ForeignPtr Tensor)
+tensor_renorm_sls = cast4 Unmanaged.tensor_renorm_sls
+
+tensor_unfold_lll
+  :: ForeignPtr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (ForeignPtr Tensor)
+tensor_unfold_lll = cast4 Unmanaged.tensor_unfold_lll
+
+tensor_equal_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (CBool)
+tensor_equal_t = cast2 Unmanaged.tensor_equal_t
+
+tensor_pow_t
+  :: ForeignPtr Tensor
+  -> ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_pow_t = cast2 Unmanaged.tensor_pow_t
+
+tensor_alias
+  :: ForeignPtr Tensor
+  -> IO (ForeignPtr Tensor)
+tensor_alias = cast1 Unmanaged.tensor_alias
 

--- a/ffi/src/Aten/Managed/Type/TensorOptions.hs
+++ b/ffi/src/Aten/Managed/Type/TensorOptions.hs
@@ -32,18 +32,18 @@ import qualified Aten.Unmanaged.Type.TensorOptions as Unmanaged
 
 
 
-newTensorOptions
+newTensorOptions_D
   :: DeviceType
   -> IO (ForeignPtr TensorOptions)
-newTensorOptions = cast1 Unmanaged.newTensorOptions
+newTensorOptions_D = cast1 Unmanaged.newTensorOptions_D
 
 
 
 
 
-tensorOptions_dtype
+tensorOptions_dtype_s
   :: ForeignPtr TensorOptions
   -> ScalarType
   -> IO (ForeignPtr TensorOptions)
-tensorOptions_dtype = cast2 Unmanaged.tensorOptions_dtype
+tensorOptions_dtype_s = cast2 Unmanaged.tensorOptions_dtype_s
 

--- a/ffi/src/Aten/Unmanaged/Type/IntArray.hs
+++ b/ffi/src/Aten/Unmanaged/Type/IntArray.hs
@@ -51,7 +51,7 @@ intArray_empty
   :: Ptr IntArray
   -> IO (CBool)
 intArray_empty _obj =
-  [C.block| bool { return ($(std::vector<int64_t>* _obj)->empty(
+  [C.block| bool { return ((*$(std::vector<int64_t>* _obj)).empty(
     ));
   }|]
 
@@ -59,25 +59,25 @@ intArray_size
   :: Ptr IntArray
   -> IO (CSize)
 intArray_size _obj =
-  [C.block| size_t { return ($(std::vector<int64_t>* _obj)->size(
+  [C.block| size_t { return ((*$(std::vector<int64_t>* _obj)).size(
     ));
   }|]
 
-intArray_at
+intArray_at_s
   :: Ptr IntArray
   -> CSize
   -> IO (Int64)
-intArray_at _obj _s =
-  [C.block| int64_t { return ($(std::vector<int64_t>* _obj)->at(
+intArray_at_s _obj _s =
+  [C.block| int64_t { return ((*$(std::vector<int64_t>* _obj)).at(
     $(size_t _s)));
   }|]
 
-intArray_push_back
+intArray_push_back_l
   :: Ptr IntArray
   -> Int64
   -> IO (())
-intArray_push_back _obj _v =
-  [C.block| void {  ($(std::vector<int64_t>* _obj)->push_back(
+intArray_push_back_l _obj _v =
+  [C.block| void {  ((*$(std::vector<int64_t>* _obj)).push_back(
     $(int64_t _v)));
   }|]
 

--- a/ffi/src/Aten/Unmanaged/Type/Scalar.hs
+++ b/ffi/src/Aten/Unmanaged/Type/Scalar.hs
@@ -37,18 +37,18 @@ newScalar  =
     );
   }|]
 
-newScalar_int
+newScalar_i
   :: CInt
   -> IO (Ptr Scalar)
-newScalar_int _a =
+newScalar_i _a =
   [C.block| at::Scalar* { return new at::Scalar(
     $(int _a));
   }|]
 
-newScalar_double
+newScalar_d
   :: CDouble
   -> IO (Ptr Scalar)
-newScalar_double _a =
+newScalar_d _a =
   [C.block| at::Scalar* { return new at::Scalar(
     $(double _a));
   }|]

--- a/ffi/src/Aten/Unmanaged/Type/SparseTensorRef.hs
+++ b/ffi/src/Aten/Unmanaged/Type/SparseTensorRef.hs
@@ -30,10 +30,10 @@ C.include "<vector>"
 
 
 
-newSparseTensorRef
+newSparseTensorRef_t
   :: Ptr Tensor
   -> IO (Ptr SparseTensorRef)
-newSparseTensorRef _x =
+newSparseTensorRef_t _x =
   [C.block| at::SparseTensorRef* { return new at::SparseTensorRef(
     *$(at::Tensor* _x));
   }|]

--- a/ffi/src/Aten/Unmanaged/Type/Tensor.hs
+++ b/ffi/src/Aten/Unmanaged/Type/Tensor.hs
@@ -37,10 +37,10 @@ newTensor  =
     );
   }|]
 
-newTensor_Tensor
+newTensor_t
   :: Ptr Tensor
   -> IO (Ptr Tensor)
-newTensor_Tensor _x =
+newTensor_t _x =
   [C.block| at::Tensor* { return new at::Tensor(
     *$(at::Tensor* _x));
   }|]
@@ -59,7 +59,7 @@ tensor_dim
   :: Ptr Tensor
   -> IO (Int64)
 tensor_dim _obj =
-  [C.block| int64_t { return ($(at::Tensor* _obj)->dim(
+  [C.block| int64_t { return ((*$(at::Tensor* _obj)).dim(
     ));
   }|]
 
@@ -67,7 +67,7 @@ tensor_storage_offset
   :: Ptr Tensor
   -> IO (Int64)
 tensor_storage_offset _obj =
-  [C.block| int64_t { return ($(at::Tensor* _obj)->storage_offset(
+  [C.block| int64_t { return ((*$(at::Tensor* _obj)).storage_offset(
     ));
   }|]
 
@@ -75,7 +75,7 @@ tensor_defined
   :: Ptr Tensor
   -> IO (CBool)
 tensor_defined _obj =
-  [C.block| bool { return ($(at::Tensor* _obj)->defined(
+  [C.block| bool { return ((*$(at::Tensor* _obj)).defined(
     ));
   }|]
 
@@ -83,15 +83,24 @@ tensor_reset
   :: Ptr Tensor
   -> IO (())
 tensor_reset _obj =
-  [C.block| void {  ($(at::Tensor* _obj)->reset(
+  [C.block| void {  ((*$(at::Tensor* _obj)).reset(
     ));
+  }|]
+
+tensor_is_same_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (CBool)
+tensor_is_same_t _obj _other =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_same(
+    *$(at::Tensor* _other)));
   }|]
 
 tensor_use_count
   :: Ptr Tensor
   -> IO (CSize)
 tensor_use_count _obj =
-  [C.block| size_t { return ($(at::Tensor* _obj)->use_count(
+  [C.block| size_t { return ((*$(at::Tensor* _obj)).use_count(
     ));
   }|]
 
@@ -99,7 +108,7 @@ tensor_weak_use_count
   :: Ptr Tensor
   -> IO (CSize)
 tensor_weak_use_count _obj =
-  [C.block| size_t { return ($(at::Tensor* _obj)->weak_use_count(
+  [C.block| size_t { return ((*$(at::Tensor* _obj)).weak_use_count(
     ));
   }|]
 
@@ -107,7 +116,7 @@ tensor_ndimension
   :: Ptr Tensor
   -> IO (Int64)
 tensor_ndimension _obj =
-  [C.block| int64_t { return ($(at::Tensor* _obj)->ndimension(
+  [C.block| int64_t { return ((*$(at::Tensor* _obj)).ndimension(
     ));
   }|]
 
@@ -115,7 +124,7 @@ tensor_is_contiguous
   :: Ptr Tensor
   -> IO (CBool)
 tensor_is_contiguous _obj =
-  [C.block| bool { return ($(at::Tensor* _obj)->is_contiguous(
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_contiguous(
     ));
   }|]
 
@@ -123,7 +132,7 @@ tensor_nbytes
   :: Ptr Tensor
   -> IO (CSize)
 tensor_nbytes _obj =
-  [C.block| size_t { return ($(at::Tensor* _obj)->nbytes(
+  [C.block| size_t { return ((*$(at::Tensor* _obj)).nbytes(
     ));
   }|]
 
@@ -131,7 +140,7 @@ tensor_itemsize
   :: Ptr Tensor
   -> IO (CSize)
 tensor_itemsize _obj =
-  [C.block| size_t { return ($(at::Tensor* _obj)->itemsize(
+  [C.block| size_t { return ((*$(at::Tensor* _obj)).itemsize(
     ));
   }|]
 
@@ -139,15 +148,52 @@ tensor_element_size
   :: Ptr Tensor
   -> IO (CSize)
 tensor_element_size _obj =
-  [C.block| size_t { return ($(at::Tensor* _obj)->element_size(
+  [C.block| size_t { return ((*$(at::Tensor* _obj)).element_size(
     ));
+  }|]
+
+tensor_has_storage
+  :: Ptr Tensor
+  -> IO (CBool)
+tensor_has_storage _obj =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).has_storage(
+    ));
+  }|]
+
+tensor_is_alias_of_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (CBool)
+tensor_is_alias_of_t _obj _other =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_alias_of(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_copy__tb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_copy__tb _obj _src _non_blocking =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).copy_(
+    *$(at::Tensor* _src)
+  , $(bool _non_blocking)));
+  }|]
+
+tensor_toType_s
+  :: Ptr Tensor
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_toType_s _obj _t =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).toType(
+    $(at::ScalarType _t)));
   }|]
 
 tensor_is_variable
   :: Ptr Tensor
   -> IO (CBool)
 tensor_is_variable _obj =
-  [C.block| bool { return ($(at::Tensor* _obj)->is_variable(
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_variable(
     ));
   }|]
 
@@ -155,7 +201,7 @@ tensor_get_device
   :: Ptr Tensor
   -> IO (Int64)
 tensor_get_device _obj =
-  [C.block| int64_t { return ($(at::Tensor* _obj)->get_device(
+  [C.block| int64_t { return ((*$(at::Tensor* _obj)).get_device(
     ));
   }|]
 
@@ -163,7 +209,7 @@ tensor_is_cuda
   :: Ptr Tensor
   -> IO (CBool)
 tensor_is_cuda _obj =
-  [C.block| bool { return ($(at::Tensor* _obj)->is_cuda(
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_cuda(
     ));
   }|]
 
@@ -171,7 +217,7 @@ tensor_is_hip
   :: Ptr Tensor
   -> IO (CBool)
 tensor_is_hip _obj =
-  [C.block| bool { return ($(at::Tensor* _obj)->is_hip(
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_hip(
     ));
   }|]
 
@@ -179,7 +225,15 @@ tensor_is_sparse
   :: Ptr Tensor
   -> IO (CBool)
 tensor_is_sparse _obj =
-  [C.block| bool { return ($(at::Tensor* _obj)->is_sparse(
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_sparse(
+    ));
+  }|]
+
+tensor_options
+  :: Ptr Tensor
+  -> IO (Ptr TensorOptions)
+tensor_options _obj =
+  [C.block| at::TensorOptions* { return new at::TensorOptions((*$(at::Tensor* _obj)).options(
     ));
   }|]
 
@@ -187,7 +241,4050 @@ tensor_print
   :: Ptr Tensor
   -> IO (())
 tensor_print _obj =
-  [C.block| void {  ($(at::Tensor* _obj)->print(
+  [C.block| void {  ((*$(at::Tensor* _obj)).print(
+    ));
+  }|]
+
+tensor__iadd__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (())
+tensor__iadd__t _obj _other =
+  [C.block| void {  ((*$(at::Tensor* _obj))+=(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor__iadd__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (())
+tensor__iadd__s _obj _other =
+  [C.block| void {  ((*$(at::Tensor* _obj))+=(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor__isub__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (())
+tensor__isub__t _obj _other =
+  [C.block| void {  ((*$(at::Tensor* _obj))-=(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor__isub__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (())
+tensor__isub__s _obj _other =
+  [C.block| void {  ((*$(at::Tensor* _obj))-=(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor__imul__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (())
+tensor__imul__t _obj _other =
+  [C.block| void {  ((*$(at::Tensor* _obj))*=(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor__imul__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (())
+tensor__imul__s _obj _other =
+  [C.block| void {  ((*$(at::Tensor* _obj))*=(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor__at__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor__at__s _obj _index =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj))[(
+    *$(at::Scalar* _index))]);
+  }|]
+
+tensor__at__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor__at__t _obj _index =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj))[(
+    *$(at::Tensor* _index))]);
+  }|]
+
+tensor__at__l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor__at__l _obj _index =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj))[(
+    $(int64_t _index))]);
+  }|]
+
+tensor_cpu
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_cpu _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cpu(
+    ));
+  }|]
+
+tensor_cuda
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_cuda _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cuda(
+    ));
+  }|]
+
+tensor_hip
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_hip _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).hip(
+    ));
+  }|]
+
+tensor_set_requires_grad_b
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_set_requires_grad_b _obj _requires_grad =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).set_requires_grad(
+    $(bool _requires_grad)));
+  }|]
+
+tensor_requires_grad
+  :: Ptr Tensor
+  -> IO (CBool)
+tensor_requires_grad _obj =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).requires_grad(
+    ));
+  }|]
+
+tensor_grad
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_grad _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).grad(
+    ));
+  }|]
+
+tensor_set_data_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (())
+tensor_set_data_t _obj _new_data =
+  [C.block| void {  ((*$(at::Tensor* _obj)).set_data(
+    *$(at::Tensor* _new_data)));
+  }|]
+
+tensor_abs
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_abs _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).abs(
+    ));
+  }|]
+
+tensor_abs_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_abs_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).abs_(
+    ));
+  }|]
+
+tensor_acos
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_acos _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).acos(
+    ));
+  }|]
+
+tensor_acos_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_acos_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).acos_(
+    ));
+  }|]
+
+tensor_add_ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_add_ts _obj _other _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).add(
+    *$(at::Tensor* _other)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_add__ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_add__ts _obj _other _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).add_(
+    *$(at::Tensor* _other)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_add_ss
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_add_ss _obj _other _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).add(
+    *$(at::Scalar* _other)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_add__ss
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_add__ss _obj _other _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).add_(
+    *$(at::Scalar* _other)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_addmv_ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addmv_ttss _obj _mat _vec _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addmv(
+    *$(at::Tensor* _mat)
+  , *$(at::Tensor* _vec)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_addmv__ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addmv__ttss _obj _mat _vec _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addmv_(
+    *$(at::Tensor* _mat)
+  , *$(at::Tensor* _vec)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_addr_ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addr_ttss _obj _vec1 _vec2 _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addr(
+    *$(at::Tensor* _vec1)
+  , *$(at::Tensor* _vec2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_addr__ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addr__ttss _obj _vec1 _vec2 _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addr_(
+    *$(at::Tensor* _vec1)
+  , *$(at::Tensor* _vec2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_all_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_all_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).all(
+    $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_allclose_tddb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> CDouble
+  -> CBool
+  -> IO (CBool)
+tensor_allclose_tddb _obj _other _rtol _atol _equal_nan =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).allclose(
+    *$(at::Tensor* _other)
+  , $(double _rtol)
+  , $(double _atol)
+  , $(bool _equal_nan)));
+  }|]
+
+tensor_any_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_any_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).any(
+    $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_argmax_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_argmax_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).argmax(
+    $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_argmax
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_argmax _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).argmax(
+    ));
+  }|]
+
+tensor_argmin_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_argmin_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).argmin(
+    $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_argmin
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_argmin _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).argmin(
+    ));
+  }|]
+
+tensor_asin
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_asin _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).asin(
+    ));
+  }|]
+
+tensor_asin_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_asin_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).asin_(
+    ));
+  }|]
+
+tensor_atan
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_atan _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).atan(
+    ));
+  }|]
+
+tensor_atan_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_atan_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).atan_(
+    ));
+  }|]
+
+tensor_baddbmm_ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_baddbmm_ttss _obj _batch1 _batch2 _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).baddbmm(
+    *$(at::Tensor* _batch1)
+  , *$(at::Tensor* _batch2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_baddbmm__ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_baddbmm__ttss _obj _batch1 _batch2 _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).baddbmm_(
+    *$(at::Tensor* _batch1)
+  , *$(at::Tensor* _batch2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_bernoulli_p
+  :: Ptr Tensor
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_bernoulli_p _obj _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).bernoulli(
+    $(at::Generator * _generator)));
+  }|]
+
+tensor_bernoulli__tp
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_bernoulli__tp _obj _p _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).bernoulli_(
+    *$(at::Tensor* _p)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_bernoulli__dp
+  :: Ptr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_bernoulli__dp _obj _p _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).bernoulli_(
+    $(double _p)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_bernoulli_dp
+  :: Ptr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_bernoulli_dp _obj _p _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).bernoulli(
+    $(double _p)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_bincount_tl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_bincount_tl _obj _weights _minlength =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).bincount(
+    *$(at::Tensor* _weights)
+  , $(int64_t _minlength)));
+  }|]
+
+tensor_bmm_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_bmm_t _obj _mat2 =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).bmm(
+    *$(at::Tensor* _mat2)));
+  }|]
+
+tensor_ceil
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_ceil _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ceil(
+    ));
+  }|]
+
+tensor_ceil_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_ceil_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ceil_(
+    ));
+  }|]
+
+tensor_clamp_max_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_clamp_max_s _obj _max =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_max(
+    *$(at::Scalar* _max)));
+  }|]
+
+tensor_clamp_max__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_clamp_max__s _obj _max =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_max_(
+    *$(at::Scalar* _max)));
+  }|]
+
+tensor_clamp_min_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_clamp_min_s _obj _min =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_min(
+    *$(at::Scalar* _min)));
+  }|]
+
+tensor_clamp_min__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_clamp_min__s _obj _min =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clamp_min_(
+    *$(at::Scalar* _min)));
+  }|]
+
+tensor_contiguous
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_contiguous _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).contiguous(
+    ));
+  }|]
+
+tensor_cos
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_cos _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cos(
+    ));
+  }|]
+
+tensor_cos_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_cos_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cos_(
+    ));
+  }|]
+
+tensor_cosh
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_cosh _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cosh(
+    ));
+  }|]
+
+tensor_cosh_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_cosh_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cosh_(
+    ));
+  }|]
+
+tensor_cumsum_ls
+  :: Ptr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_cumsum_ls _obj _dim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cumsum(
+    $(int64_t _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_cumsum_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_cumsum_l _obj _dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cumsum(
+    $(int64_t _dim)));
+  }|]
+
+tensor_cumprod_ls
+  :: Ptr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_cumprod_ls _obj _dim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cumprod(
+    $(int64_t _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_cumprod_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_cumprod_l _obj _dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cumprod(
+    $(int64_t _dim)));
+  }|]
+
+tensor_det
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_det _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).det(
+    ));
+  }|]
+
+tensor_diag_embed_lll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_diag_embed_lll _obj _offset _dim1 _dim2 =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).diag_embed(
+    $(int64_t _offset)
+  , $(int64_t _dim1)
+  , $(int64_t _dim2)));
+  }|]
+
+tensor_diagflat_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_diagflat_l _obj _offset =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).diagflat(
+    $(int64_t _offset)));
+  }|]
+
+tensor_diagonal_lll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_diagonal_lll _obj _offset _dim1 _dim2 =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).diagonal(
+    $(int64_t _offset)
+  , $(int64_t _dim1)
+  , $(int64_t _dim2)));
+  }|]
+
+tensor_div_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_div_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).div(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_div__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_div__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).div_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_div_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_div_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).div(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_div__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_div__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).div_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_dot_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_dot_t _obj _tensor =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).dot(
+    *$(at::Tensor* _tensor)));
+  }|]
+
+tensor_resize__l
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_resize__l _obj _size =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).resize_(
+    *$(std::vector<int64_t>* _size)));
+  }|]
+
+tensor_erf
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_erf _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).erf(
+    ));
+  }|]
+
+tensor_erf_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_erf_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).erf_(
+    ));
+  }|]
+
+tensor_erfc
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_erfc _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).erfc(
+    ));
+  }|]
+
+tensor_erfc_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_erfc_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).erfc_(
+    ));
+  }|]
+
+tensor_exp
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_exp _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).exp(
+    ));
+  }|]
+
+tensor_exp_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_exp_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).exp_(
+    ));
+  }|]
+
+tensor_expm1
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_expm1 _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).expm1(
+    ));
+  }|]
+
+tensor_expm1_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_expm1_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).expm1_(
+    ));
+  }|]
+
+tensor_expand_lb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_expand_lb _obj _size _implicit =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).expand(
+    *$(std::vector<int64_t>* _size)
+  , $(bool _implicit)));
+  }|]
+
+tensor_expand_as_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_expand_as_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).expand_as(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_flatten_ll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_flatten_ll _obj _start_dim _end_dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).flatten(
+    $(int64_t _start_dim)
+  , $(int64_t _end_dim)));
+  }|]
+
+tensor_fill__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_fill__s _obj _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).fill_(
+    *$(at::Scalar* _value)));
+  }|]
+
+tensor_fill__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_fill__t _obj _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).fill_(
+    *$(at::Tensor* _value)));
+  }|]
+
+tensor_floor
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_floor _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).floor(
+    ));
+  }|]
+
+tensor_floor_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_floor_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).floor_(
+    ));
+  }|]
+
+tensor_ger_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_ger_t _obj _vec2 =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ger(
+    *$(at::Tensor* _vec2)));
+  }|]
+
+tensor_fft_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_fft_lb _obj _signal_ndim _normalized =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).fft(
+    $(int64_t _signal_ndim)
+  , $(bool _normalized)));
+  }|]
+
+tensor_ifft_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_ifft_lb _obj _signal_ndim _normalized =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ifft(
+    $(int64_t _signal_ndim)
+  , $(bool _normalized)));
+  }|]
+
+tensor_rfft_lbb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_rfft_lbb _obj _signal_ndim _normalized _onesided =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).rfft(
+    $(int64_t _signal_ndim)
+  , $(bool _normalized)
+  , $(bool _onesided)));
+  }|]
+
+tensor_irfft_lbbl
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> CBool
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_irfft_lbbl _obj _signal_ndim _normalized _onesided _signal_sizes =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).irfft(
+    $(int64_t _signal_ndim)
+  , $(bool _normalized)
+  , $(bool _onesided)
+  , *$(std::vector<int64_t>* _signal_sizes)));
+  }|]
+
+tensor_index_l
+  :: Ptr Tensor
+  -> Ptr TensorList
+  -> IO (Ptr Tensor)
+tensor_index_l _obj _indices =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index(
+    *$(at::TensorList* _indices)));
+  }|]
+
+tensor_index_copy__ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_index_copy__ltt _obj _dim _index _source =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_copy_(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)));
+  }|]
+
+tensor_index_copy_ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_index_copy_ltt _obj _dim _index _source =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_copy(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)));
+  }|]
+
+tensor_index_put__ltb
+  :: Ptr Tensor
+  -> Ptr TensorList
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_index_put__ltb _obj _indices _values _accumulate =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_put_(
+    *$(at::TensorList* _indices)
+  , *$(at::Tensor* _values)
+  , $(bool _accumulate)));
+  }|]
+
+tensor_index_put_ltb
+  :: Ptr Tensor
+  -> Ptr TensorList
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_index_put_ltb _obj _indices _values _accumulate =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_put(
+    *$(at::TensorList* _indices)
+  , *$(at::Tensor* _values)
+  , $(bool _accumulate)));
+  }|]
+
+tensor_inverse
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_inverse _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).inverse(
+    ));
+  }|]
+
+tensor_isclose_tddb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CDouble
+  -> CDouble
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_isclose_tddb _obj _other _rtol _atol _equal_nan =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).isclose(
+    *$(at::Tensor* _other)
+  , $(double _rtol)
+  , $(double _atol)
+  , $(bool _equal_nan)));
+  }|]
+
+tensor_is_distributed
+  :: Ptr Tensor
+  -> IO (CBool)
+tensor_is_distributed _obj =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_distributed(
+    ));
+  }|]
+
+tensor_is_floating_point
+  :: Ptr Tensor
+  -> IO (CBool)
+tensor_is_floating_point _obj =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_floating_point(
+    ));
+  }|]
+
+tensor_is_complex
+  :: Ptr Tensor
+  -> IO (CBool)
+tensor_is_complex _obj =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_complex(
+    ));
+  }|]
+
+tensor_is_nonzero
+  :: Ptr Tensor
+  -> IO (CBool)
+tensor_is_nonzero _obj =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_nonzero(
+    ));
+  }|]
+
+tensor_is_same_size_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (CBool)
+tensor_is_same_size_t _obj _other =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_same_size(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_is_signed
+  :: Ptr Tensor
+  -> IO (CBool)
+tensor_is_signed _obj =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_signed(
+    ));
+  }|]
+
+tensor_kthvalue_llb
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_kthvalue_llb _obj _k _dim _keepdim =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).kthvalue(
+    $(int64_t _k)
+  , $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_log
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_log _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log(
+    ));
+  }|]
+
+tensor_log_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_log_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log_(
+    ));
+  }|]
+
+tensor_log10
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_log10 _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log10(
+    ));
+  }|]
+
+tensor_log10_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_log10_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log10_(
+    ));
+  }|]
+
+tensor_log1p
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_log1p _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log1p(
+    ));
+  }|]
+
+tensor_log1p_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_log1p_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log1p_(
+    ));
+  }|]
+
+tensor_log2
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_log2 _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log2(
+    ));
+  }|]
+
+tensor_log2_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_log2_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log2_(
+    ));
+  }|]
+
+tensor_logdet
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_logdet _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).logdet(
+    ));
+  }|]
+
+tensor_log_softmax_ls
+  :: Ptr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_log_softmax_ls _obj _dim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log_softmax(
+    $(int64_t _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_log_softmax_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_log_softmax_l _obj _dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log_softmax(
+    $(int64_t _dim)));
+  }|]
+
+tensor_logsumexp_lb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_logsumexp_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).logsumexp(
+    *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_matmul_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_matmul_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).matmul(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_matrix_power_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_matrix_power_l _obj _n =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).matrix_power(
+    $(int64_t _n)));
+  }|]
+
+tensor_max_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_max_lb _obj _dim _keepdim =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).max(
+    $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_max_values_lb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_max_values_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).max_values(
+    *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_mean_s
+  :: Ptr Tensor
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_mean_s _obj _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mean(
+    $(at::ScalarType _dtype)));
+  }|]
+
+tensor_mean
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_mean _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mean(
+    ));
+  }|]
+
+tensor_mean_lbs
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_mean_lbs _obj _dim _keepdim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mean(
+    *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_mean_lb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_mean_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mean(
+    *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_mean_ls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_mean_ls _obj _dim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mean(
+    *$(std::vector<int64_t>* _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_median_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_median_lb _obj _dim _keepdim =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).median(
+    $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_min_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_min_lb _obj _dim _keepdim =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).min(
+    $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_min_values_lb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_min_values_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).min_values(
+    *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_mm_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_mm_t _obj _mat2 =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mm(
+    *$(at::Tensor* _mat2)));
+  }|]
+
+tensor_mode_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_mode_lb _obj _dim _keepdim =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).mode(
+    $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_mul_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_mul_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mul(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_mul__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_mul__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mul_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_mul_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_mul_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mul(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_mul__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_mul__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mul_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_mv_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_mv_t _obj _vec =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mv(
+    *$(at::Tensor* _vec)));
+  }|]
+
+tensor_mvlgamma_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_mvlgamma_l _obj _p =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mvlgamma(
+    $(int64_t _p)));
+  }|]
+
+tensor_mvlgamma__l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_mvlgamma__l _obj _p =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).mvlgamma_(
+    $(int64_t _p)));
+  }|]
+
+tensor_narrow_copy_lll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_narrow_copy_lll _obj _dim _start _length =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).narrow_copy(
+    $(int64_t _dim)
+  , $(int64_t _start)
+  , $(int64_t _length)));
+  }|]
+
+tensor_narrow_lll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_narrow_lll _obj _dim _start _length =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).narrow(
+    $(int64_t _dim)
+  , $(int64_t _start)
+  , $(int64_t _length)));
+  }|]
+
+tensor_permute_l
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_permute_l _obj _dims =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).permute(
+    *$(std::vector<int64_t>* _dims)));
+  }|]
+
+tensor_pin_memory
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_pin_memory _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).pin_memory(
+    ));
+  }|]
+
+tensor_pinverse_d
+  :: Ptr Tensor
+  -> CDouble
+  -> IO (Ptr Tensor)
+tensor_pinverse_d _obj _rcond =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).pinverse(
+    $(double _rcond)));
+  }|]
+
+tensor_repeat_l
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_repeat_l _obj _repeats =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).repeat(
+    *$(std::vector<int64_t>* _repeats)));
+  }|]
+
+tensor_reshape_l
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_reshape_l _obj _shape =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).reshape(
+    *$(std::vector<int64_t>* _shape)));
+  }|]
+
+tensor_reshape_as_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_reshape_as_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).reshape_as(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_round
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_round _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).round(
+    ));
+  }|]
+
+tensor_round_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_round_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).round_(
+    ));
+  }|]
+
+tensor_relu
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_relu _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).relu(
+    ));
+  }|]
+
+tensor_relu_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_relu_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).relu_(
+    ));
+  }|]
+
+tensor_prelu_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_prelu_t _obj _weight =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).prelu(
+    *$(at::Tensor* _weight)));
+  }|]
+
+tensor_prelu_backward_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (Tensor,Tensor))
+tensor_prelu_backward_tt _obj _grad_output _weight =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).prelu_backward(
+    *$(at::Tensor* _grad_output)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+tensor_hardshrink_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_hardshrink_s _obj _lambd =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).hardshrink(
+    *$(at::Scalar* _lambd)));
+  }|]
+
+tensor_hardshrink_backward_ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_hardshrink_backward_ts _obj _grad_out _lambd =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).hardshrink_backward(
+    *$(at::Tensor* _grad_out)
+  , *$(at::Scalar* _lambd)));
+  }|]
+
+tensor_rsqrt
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_rsqrt _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).rsqrt(
+    ));
+  }|]
+
+tensor_rsqrt_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_rsqrt_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).rsqrt_(
+    ));
+  }|]
+
+tensor_select_ll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_select_ll _obj _dim _index =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).select(
+    $(int64_t _dim)
+  , $(int64_t _index)));
+  }|]
+
+tensor_sigmoid
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sigmoid _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sigmoid(
+    ));
+  }|]
+
+tensor_sigmoid_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sigmoid_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sigmoid_(
+    ));
+  }|]
+
+tensor_sin
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sin _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sin(
+    ));
+  }|]
+
+tensor_sin_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sin_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sin_(
+    ));
+  }|]
+
+tensor_sinh
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sinh _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sinh(
+    ));
+  }|]
+
+tensor_sinh_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sinh_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sinh_(
+    ));
+  }|]
+
+tensor_detach
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_detach _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).detach(
+    ));
+  }|]
+
+tensor_detach_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_detach_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).detach_(
+    ));
+  }|]
+
+tensor_size_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Int64)
+tensor_size_l _obj _dim =
+  [C.block| int64_t { return ((*$(at::Tensor* _obj)).size(
+    $(int64_t _dim)));
+  }|]
+
+tensor_slice_llll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_slice_llll _obj _dim _start _end _step =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).slice(
+    $(int64_t _dim)
+  , $(int64_t _start)
+  , $(int64_t _end)
+  , $(int64_t _step)));
+  }|]
+
+tensor_slogdet
+  :: Ptr Tensor
+  -> IO (Ptr (Tensor,Tensor))
+tensor_slogdet _obj =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).slogdet(
+    ));
+  }|]
+
+tensor_smm_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_smm_t _obj _mat2 =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).smm(
+    *$(at::Tensor* _mat2)));
+  }|]
+
+tensor_softmax_ls
+  :: Ptr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_softmax_ls _obj _dim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).softmax(
+    $(int64_t _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_softmax_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_softmax_l _obj _dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).softmax(
+    $(int64_t _dim)));
+  }|]
+
+tensor_squeeze
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_squeeze _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).squeeze(
+    ));
+  }|]
+
+tensor_squeeze_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_squeeze_l _obj _dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).squeeze(
+    $(int64_t _dim)));
+  }|]
+
+tensor_squeeze_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_squeeze_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).squeeze_(
+    ));
+  }|]
+
+tensor_squeeze__l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_squeeze__l _obj _dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).squeeze_(
+    $(int64_t _dim)));
+  }|]
+
+tensor_sspaddmm_ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_sspaddmm_ttss _obj _mat1 _mat2 _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sspaddmm(
+    *$(at::Tensor* _mat1)
+  , *$(at::Tensor* _mat2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_stride_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Int64)
+tensor_stride_l _obj _dim =
+  [C.block| int64_t { return ((*$(at::Tensor* _obj)).stride(
+    $(int64_t _dim)));
+  }|]
+
+tensor_sum_s
+  :: Ptr Tensor
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_sum_s _obj _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sum(
+    $(at::ScalarType _dtype)));
+  }|]
+
+tensor_sum
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sum _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sum(
+    ));
+  }|]
+
+tensor_sum_lbs
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_sum_lbs _obj _dim _keepdim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sum(
+    *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_sum_lb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_sum_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sum(
+    *$(std::vector<int64_t>* _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_sum_ls
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_sum_ls _obj _dim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sum(
+    *$(std::vector<int64_t>* _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_sum_to_size_l
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_sum_to_size_l _obj _size =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sum_to_size(
+    *$(std::vector<int64_t>* _size)));
+  }|]
+
+tensor_sqrt
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sqrt _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sqrt(
+    ));
+  }|]
+
+tensor_sqrt_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sqrt_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sqrt_(
+    ));
+  }|]
+
+tensor_std_b
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_std_b _obj _unbiased =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).std(
+    $(bool _unbiased)));
+  }|]
+
+tensor_std_lbb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_std_lbb _obj _dim _unbiased _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).std(
+    *$(std::vector<int64_t>* _dim)
+  , $(bool _unbiased)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_prod_s
+  :: Ptr Tensor
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_prod_s _obj _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).prod(
+    $(at::ScalarType _dtype)));
+  }|]
+
+tensor_prod
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_prod _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).prod(
+    ));
+  }|]
+
+tensor_prod_lbs
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_prod_lbs _obj _dim _keepdim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).prod(
+    $(int64_t _dim)
+  , $(bool _keepdim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_prod_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_prod_lb _obj _dim _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).prod(
+    $(int64_t _dim)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_prod_ls
+  :: Ptr Tensor
+  -> Int64
+  -> ScalarType
+  -> IO (Ptr Tensor)
+tensor_prod_ls _obj _dim _dtype =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).prod(
+    $(int64_t _dim)
+  , $(at::ScalarType _dtype)));
+  }|]
+
+tensor_t
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_t _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).t(
+    ));
+  }|]
+
+tensor_t_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_t_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).t_(
+    ));
+  }|]
+
+tensor_tan
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_tan _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).tan(
+    ));
+  }|]
+
+tensor_tan_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_tan_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).tan_(
+    ));
+  }|]
+
+tensor_tanh
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_tanh _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).tanh(
+    ));
+  }|]
+
+tensor_tanh_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_tanh_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).tanh_(
+    ));
+  }|]
+
+tensor_transpose_ll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_transpose_ll _obj _dim0 _dim1 =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).transpose(
+    $(int64_t _dim0)
+  , $(int64_t _dim1)));
+  }|]
+
+tensor_transpose__ll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_transpose__ll _obj _dim0 _dim1 =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).transpose_(
+    $(int64_t _dim0)
+  , $(int64_t _dim1)));
+  }|]
+
+tensor_flip_l
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_flip_l _obj _dims =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).flip(
+    *$(std::vector<int64_t>* _dims)));
+  }|]
+
+tensor_roll_ll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_roll_ll _obj _shifts _dims =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).roll(
+    *$(std::vector<int64_t>* _shifts)
+  , *$(std::vector<int64_t>* _dims)));
+  }|]
+
+tensor_rot90_ll
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_rot90_ll _obj _k _dims =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).rot90(
+    $(int64_t _k)
+  , *$(std::vector<int64_t>* _dims)));
+  }|]
+
+tensor_trunc
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_trunc _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).trunc(
+    ));
+  }|]
+
+tensor_trunc_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_trunc_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).trunc_(
+    ));
+  }|]
+
+tensor_type_as_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_type_as_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).type_as(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_unsqueeze_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_unsqueeze_l _obj _dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).unsqueeze(
+    $(int64_t _dim)));
+  }|]
+
+tensor_unsqueeze__l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_unsqueeze__l _obj _dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).unsqueeze_(
+    $(int64_t _dim)));
+  }|]
+
+tensor_var_b
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_var_b _obj _unbiased =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).var(
+    $(bool _unbiased)));
+  }|]
+
+tensor_var_lbb
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_var_lbb _obj _dim _unbiased _keepdim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).var(
+    *$(std::vector<int64_t>* _dim)
+  , $(bool _unbiased)
+  , $(bool _keepdim)));
+  }|]
+
+tensor_view_as_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_view_as_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).view_as(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_where_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_where_tt _obj _condition _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).where(
+    *$(at::Tensor* _condition)
+  , *$(at::Tensor* _other)));
+  }|]
+
+tensor_norm_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_norm_s _obj _p =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).norm(
+    *$(at::Scalar* _p)));
+  }|]
+
+tensor_clone
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_clone _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).clone(
+    ));
+  }|]
+
+tensor_resize_as__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_resize_as__t _obj _the_template =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).resize_as_(
+    *$(at::Tensor* _the_template)));
+  }|]
+
+tensor_pow_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_pow_s _obj _exponent =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).pow(
+    *$(at::Scalar* _exponent)));
+  }|]
+
+tensor_zero_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_zero_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).zero_(
+    ));
+  }|]
+
+tensor_sub_ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_sub_ts _obj _other _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sub(
+    *$(at::Tensor* _other)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_sub__ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_sub__ts _obj _other _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sub_(
+    *$(at::Tensor* _other)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_sub_ss
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_sub_ss _obj _other _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sub(
+    *$(at::Scalar* _other)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_sub__ss
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_sub__ss _obj _other _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sub_(
+    *$(at::Scalar* _other)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_addmm_ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addmm_ttss _obj _mat1 _mat2 _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addmm(
+    *$(at::Tensor* _mat1)
+  , *$(at::Tensor* _mat2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_addmm__ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addmm__ttss _obj _mat1 _mat2 _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addmm_(
+    *$(at::Tensor* _mat1)
+  , *$(at::Tensor* _mat2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_sparse_resize__lll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_sparse_resize__lll _obj _size _sparse_dim _dense_dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sparse_resize_(
+    *$(std::vector<int64_t>* _size)
+  , $(int64_t _sparse_dim)
+  , $(int64_t _dense_dim)));
+  }|]
+
+tensor_sparse_resize_and_clear__lll
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_sparse_resize_and_clear__lll _obj _size _sparse_dim _dense_dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sparse_resize_and_clear_(
+    *$(std::vector<int64_t>* _size)
+  , $(int64_t _sparse_dim)
+  , $(int64_t _dense_dim)));
+  }|]
+
+tensor_sparse_mask_r
+  :: Ptr Tensor
+  -> Ptr SparseTensorRef
+  -> IO (Ptr Tensor)
+tensor_sparse_mask_r _obj _mask =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sparse_mask(
+    *$(at::SparseTensorRef* _mask)));
+  }|]
+
+tensor_to_dense
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_to_dense _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).to_dense(
+    ));
+  }|]
+
+tensor_sparse_dim
+  :: Ptr Tensor
+  -> IO (Int64)
+tensor_sparse_dim _obj =
+  [C.block| int64_t { return ((*$(at::Tensor* _obj)).sparse_dim(
+    ));
+  }|]
+
+tensor__dimI
+  :: Ptr Tensor
+  -> IO (Int64)
+tensor__dimI _obj =
+  [C.block| int64_t { return ((*$(at::Tensor* _obj))._dimI(
+    ));
+  }|]
+
+tensor_dense_dim
+  :: Ptr Tensor
+  -> IO (Int64)
+tensor_dense_dim _obj =
+  [C.block| int64_t { return ((*$(at::Tensor* _obj)).dense_dim(
+    ));
+  }|]
+
+tensor__dimV
+  :: Ptr Tensor
+  -> IO (Int64)
+tensor__dimV _obj =
+  [C.block| int64_t { return ((*$(at::Tensor* _obj))._dimV(
+    ));
+  }|]
+
+tensor__nnz
+  :: Ptr Tensor
+  -> IO (Int64)
+tensor__nnz _obj =
+  [C.block| int64_t { return ((*$(at::Tensor* _obj))._nnz(
+    ));
+  }|]
+
+tensor_coalesce
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_coalesce _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).coalesce(
+    ));
+  }|]
+
+tensor_is_coalesced
+  :: Ptr Tensor
+  -> IO (CBool)
+tensor_is_coalesced _obj =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_coalesced(
+    ));
+  }|]
+
+tensor__indices
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor__indices _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj))._indices(
+    ));
+  }|]
+
+tensor__values
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor__values _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj))._values(
+    ));
+  }|]
+
+tensor__coalesced__b
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor__coalesced__b _obj _coalesced =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj))._coalesced_(
+    $(bool _coalesced)));
+  }|]
+
+tensor_indices
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_indices _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).indices(
+    ));
+  }|]
+
+tensor_values
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_values _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).values(
+    ));
+  }|]
+
+tensor_numel
+  :: Ptr Tensor
+  -> IO (Int64)
+tensor_numel _obj =
+  [C.block| int64_t { return ((*$(at::Tensor* _obj)).numel(
+    ));
+  }|]
+
+tensor_to_sparse_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_to_sparse_l _obj _sparse_dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).to_sparse(
+    $(int64_t _sparse_dim)));
+  }|]
+
+tensor_to_sparse
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_to_sparse _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).to_sparse(
+    ));
+  }|]
+
+tensor_to_obb
+  :: Ptr Tensor
+  -> Ptr TensorOptions
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_to_obb _obj _options _non_blocking _copy =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).to(
+    *$(at::TensorOptions* _options)
+  , $(bool _non_blocking)
+  , $(bool _copy)));
+  }|]
+
+tensor_to_Dsbb
+  :: Ptr Tensor
+  -> DeviceType
+  -> ScalarType
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_to_Dsbb _obj _device _dtype _non_blocking _copy =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).to(
+    $(at::DeviceType _device)
+  , $(at::ScalarType _dtype)
+  , $(bool _non_blocking)
+  , $(bool _copy)));
+  }|]
+
+tensor_to_sbb
+  :: Ptr Tensor
+  -> ScalarType
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_to_sbb _obj _dtype _non_blocking _copy =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).to(
+    $(at::ScalarType _dtype)
+  , $(bool _non_blocking)
+  , $(bool _copy)));
+  }|]
+
+tensor_to_tbb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_to_tbb _obj _other _non_blocking _copy =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).to(
+    *$(at::Tensor* _other)
+  , $(bool _non_blocking)
+  , $(bool _copy)));
+  }|]
+
+tensor_item
+  :: Ptr Tensor
+  -> IO (Ptr Scalar)
+tensor_item _obj =
+  [C.block| at::Scalar* { return new at::Scalar((*$(at::Tensor* _obj)).item(
+    ));
+  }|]
+
+tensor_data_ptr
+  :: Ptr Tensor
+  -> IO (Ptr ())
+tensor_data_ptr _obj =
+  [C.block| void * { return ((*$(at::Tensor* _obj)).data_ptr(
+    ));
+  }|]
+
+tensor_set__S
+  :: Ptr Tensor
+  -> Ptr Storage
+  -> IO (Ptr Tensor)
+tensor_set__S _obj _source =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).set_(
+    *$(at::Storage* _source)));
+  }|]
+
+tensor_set__Slll
+  :: Ptr Tensor
+  -> Ptr Storage
+  -> Int64
+  -> Ptr IntArray
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_set__Slll _obj _source _storage_offset _size _stride =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).set_(
+    *$(at::Storage* _source)
+  , $(int64_t _storage_offset)
+  , *$(std::vector<int64_t>* _size)
+  , *$(std::vector<int64_t>* _stride)));
+  }|]
+
+tensor_set__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_set__t _obj _source =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).set_(
+    *$(at::Tensor* _source)));
+  }|]
+
+tensor_set_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_set_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).set_(
+    ));
+  }|]
+
+tensor_is_set_to_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (CBool)
+tensor_is_set_to_t _obj _tensor =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).is_set_to(
+    *$(at::Tensor* _tensor)));
+  }|]
+
+tensor_masked_fill__ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_masked_fill__ts _obj _mask _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).masked_fill_(
+    *$(at::Tensor* _mask)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_masked_fill_ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_masked_fill_ts _obj _mask _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).masked_fill(
+    *$(at::Tensor* _mask)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_masked_fill__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_masked_fill__tt _obj _mask _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).masked_fill_(
+    *$(at::Tensor* _mask)
+  , *$(at::Tensor* _value)));
+  }|]
+
+tensor_masked_fill_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_masked_fill_tt _obj _mask _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).masked_fill(
+    *$(at::Tensor* _mask)
+  , *$(at::Tensor* _value)));
+  }|]
+
+tensor_masked_scatter__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_masked_scatter__tt _obj _mask _source =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).masked_scatter_(
+    *$(at::Tensor* _mask)
+  , *$(at::Tensor* _source)));
+  }|]
+
+tensor_masked_scatter_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_masked_scatter_tt _obj _mask _source =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).masked_scatter(
+    *$(at::Tensor* _mask)
+  , *$(at::Tensor* _source)));
+  }|]
+
+tensor_view_l
+  :: Ptr Tensor
+  -> Ptr IntArray
+  -> IO (Ptr Tensor)
+tensor_view_l _obj _size =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).view(
+    *$(std::vector<int64_t>* _size)));
+  }|]
+
+tensor_put__ttb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_put__ttb _obj _index _source _accumulate =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).put_(
+    *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)
+  , $(bool _accumulate)));
+  }|]
+
+tensor_index_add__ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_index_add__ltt _obj _dim _index _source =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_add_(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)));
+  }|]
+
+tensor_index_add_ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_index_add_ltt _obj _dim _index _source =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_add(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _source)));
+  }|]
+
+tensor_index_fill__lts
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_index_fill__lts _obj _dim _index _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_fill_(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_index_fill_lts
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_index_fill_lts _obj _dim _index _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_fill(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_index_fill__ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_index_fill__ltt _obj _dim _index _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_fill_(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _value)));
+  }|]
+
+tensor_index_fill_ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_index_fill_ltt _obj _dim _index _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_fill(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _value)));
+  }|]
+
+tensor_scatter__ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_scatter__ltt _obj _dim _index _src =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).scatter_(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _src)));
+  }|]
+
+tensor_scatter_ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_scatter_ltt _obj _dim _index _src =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).scatter(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _src)));
+  }|]
+
+tensor_scatter__lts
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_scatter__lts _obj _dim _index _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).scatter_(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_scatter_lts
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_scatter_lts _obj _dim _index _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).scatter(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_scatter_add__ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_scatter_add__ltt _obj _dim _index _src =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).scatter_add_(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _src)));
+  }|]
+
+tensor_scatter_add_ltt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_scatter_add_ltt _obj _dim _index _src =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).scatter_add(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , *$(at::Tensor* _src)));
+  }|]
+
+tensor_lt__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_lt__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lt_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_lt__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_lt__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lt_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_gt__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_gt__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).gt_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_gt__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_gt__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).gt_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_le__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_le__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).le_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_le__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_le__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).le_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_ge__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_ge__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ge_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_ge__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_ge__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ge_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_eq__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_eq__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).eq_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_eq__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_eq__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).eq_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_ne__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_ne__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ne_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_ne__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_ne__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ne_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___and___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___and___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__and__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___and___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___and___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__and__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___iand___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___iand___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__iand__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___iand___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___iand___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__iand__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___or___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___or___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__or__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___or___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___or___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__or__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___ior___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___ior___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__ior__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___ior___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___ior___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__ior__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___xor___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___xor___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__xor__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___xor___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___xor___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__xor__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___ixor___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___ixor___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__ixor__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___ixor___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___ixor___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__ixor__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___lshift___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___lshift___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__lshift__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___lshift___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___lshift___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__lshift__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___ilshift___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___ilshift___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__ilshift__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___ilshift___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___ilshift___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__ilshift__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___rshift___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___rshift___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__rshift__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___rshift___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___rshift___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__rshift__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor___irshift___s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor___irshift___s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__irshift__(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor___irshift___t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor___irshift___t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).__irshift__(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_lgamma_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_lgamma_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lgamma_(
+    ));
+  }|]
+
+tensor_atan2__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_atan2__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).atan2_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_tril__l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_tril__l _obj _diagonal =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).tril_(
+    $(int64_t _diagonal)));
+  }|]
+
+tensor_triu__l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_triu__l _obj _diagonal =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).triu_(
+    $(int64_t _diagonal)));
+  }|]
+
+tensor_digamma_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_digamma_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).digamma_(
+    ));
+  }|]
+
+tensor_polygamma__l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_polygamma__l _obj _n =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).polygamma_(
+    $(int64_t _n)));
+  }|]
+
+tensor_erfinv_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_erfinv_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).erfinv_(
+    ));
+  }|]
+
+tensor_frac_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_frac_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).frac_(
+    ));
+  }|]
+
+tensor_renorm__sls
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Int64
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_renorm__sls _obj _p _dim _maxnorm =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).renorm_(
+    *$(at::Scalar* _p)
+  , $(int64_t _dim)
+  , *$(at::Scalar* _maxnorm)));
+  }|]
+
+tensor_reciprocal_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_reciprocal_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).reciprocal_(
+    ));
+  }|]
+
+tensor_neg_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_neg_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).neg_(
+    ));
+  }|]
+
+tensor_pow__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_pow__s _obj _exponent =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).pow_(
+    *$(at::Scalar* _exponent)));
+  }|]
+
+tensor_pow__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_pow__t _obj _exponent =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).pow_(
+    *$(at::Tensor* _exponent)));
+  }|]
+
+tensor_lerp__ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_lerp__ts _obj _end _weight =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lerp_(
+    *$(at::Tensor* _end)
+  , *$(at::Scalar* _weight)));
+  }|]
+
+tensor_lerp__tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_lerp__tt _obj _end _weight =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lerp_(
+    *$(at::Tensor* _end)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+tensor_sign_
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sign_ _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sign_(
+    ));
+  }|]
+
+tensor_fmod__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_fmod__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).fmod_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_fmod__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_fmod__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).fmod_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_remainder__s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_remainder__s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).remainder_(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_remainder__t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_remainder__t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).remainder_(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_addbmm__ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addbmm__ttss _obj _batch1 _batch2 _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addbmm_(
+    *$(at::Tensor* _batch1)
+  , *$(at::Tensor* _batch2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_addbmm_ttss
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addbmm_ttss _obj _batch1 _batch2 _beta _alpha =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addbmm(
+    *$(at::Tensor* _batch1)
+  , *$(at::Tensor* _batch2)
+  , *$(at::Scalar* _beta)
+  , *$(at::Scalar* _alpha)));
+  }|]
+
+tensor_addcmul__tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addcmul__tts _obj _tensor1 _tensor2 _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addcmul_(
+    *$(at::Tensor* _tensor1)
+  , *$(at::Tensor* _tensor2)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_addcdiv__tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addcdiv__tts _obj _tensor1 _tensor2 _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addcdiv_(
+    *$(at::Tensor* _tensor1)
+  , *$(at::Tensor* _tensor2)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_random__llp
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_random__llp _obj _from _to _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).random_(
+    $(int64_t _from)
+  , $(int64_t _to)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_random__lp
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_random__lp _obj _to _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).random_(
+    $(int64_t _to)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_random__p
+  :: Ptr Tensor
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_random__p _obj _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).random_(
+    $(at::Generator * _generator)));
+  }|]
+
+tensor_uniform__ddp
+  :: Ptr Tensor
+  -> CDouble
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_uniform__ddp _obj _from _to _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).uniform_(
+    $(double _from)
+  , $(double _to)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_normal__ddp
+  :: Ptr Tensor
+  -> CDouble
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_normal__ddp _obj _mean _std _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).normal_(
+    $(double _mean)
+  , $(double _std)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_cauchy__ddp
+  :: Ptr Tensor
+  -> CDouble
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_cauchy__ddp _obj _median _sigma _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cauchy_(
+    $(double _median)
+  , $(double _sigma)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_log_normal__ddp
+  :: Ptr Tensor
+  -> CDouble
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_log_normal__ddp _obj _mean _std _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).log_normal_(
+    $(double _mean)
+  , $(double _std)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_exponential__dp
+  :: Ptr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_exponential__dp _obj _lambd _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).exponential_(
+    $(double _lambd)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_geometric__dp
+  :: Ptr Tensor
+  -> CDouble
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_geometric__dp _obj _p _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).geometric_(
+    $(double _p)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_diag_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_diag_l _obj _diagonal =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).diag(
+    $(int64_t _diagonal)));
+  }|]
+
+tensor_cross_tl
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_cross_tl _obj _other _dim =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cross(
+    *$(at::Tensor* _other)
+  , $(int64_t _dim)));
+  }|]
+
+tensor_triu_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_triu_l _obj _diagonal =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).triu(
+    $(int64_t _diagonal)));
+  }|]
+
+tensor_tril_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_tril_l _obj _diagonal =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).tril(
+    $(int64_t _diagonal)));
+  }|]
+
+tensor_trace
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_trace _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).trace(
+    ));
+  }|]
+
+tensor_ne_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_ne_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ne(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_ne_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_ne_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ne(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_eq_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_eq_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).eq(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_eq_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_eq_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).eq(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_ge_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_ge_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ge(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_ge_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_ge_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ge(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_le_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_le_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).le(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_le_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_le_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).le(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_gt_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_gt_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).gt(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_gt_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_gt_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).gt(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_lt_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_lt_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lt(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_lt_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_lt_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lt(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_take_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_take_t _obj _index =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).take(
+    *$(at::Tensor* _index)));
+  }|]
+
+tensor_index_select_lt
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_index_select_lt _obj _dim _index =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).index_select(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)));
+  }|]
+
+tensor_masked_select_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_masked_select_t _obj _mask =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).masked_select(
+    *$(at::Tensor* _mask)));
+  }|]
+
+tensor_nonzero
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_nonzero _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).nonzero(
+    ));
+  }|]
+
+tensor_gather_ltb
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_gather_ltb _obj _dim _index _sparse_grad =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).gather(
+    $(int64_t _dim)
+  , *$(at::Tensor* _index)
+  , $(bool _sparse_grad)));
+  }|]
+
+tensor_addcmul_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addcmul_tts _obj _tensor1 _tensor2 _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addcmul(
+    *$(at::Tensor* _tensor1)
+  , *$(at::Tensor* _tensor2)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_addcdiv_tts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_addcdiv_tts _obj _tensor1 _tensor2 _value =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).addcdiv(
+    *$(at::Tensor* _tensor1)
+  , *$(at::Tensor* _tensor2)
+  , *$(at::Scalar* _value)));
+  }|]
+
+tensor_gels_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (Tensor,Tensor))
+tensor_gels_t _obj _A =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).gels(
+    *$(at::Tensor* _A)));
+  }|]
+
+tensor_trtrs_tbbb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> CBool
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_trtrs_tbbb _obj _A _upper _transpose _unitriangular =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).trtrs(
+    *$(at::Tensor* _A)
+  , $(bool _upper)
+  , $(bool _transpose)
+  , $(bool _unitriangular)));
+  }|]
+
+tensor_symeig_bb
+  :: Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_symeig_bb _obj _eigenvectors _upper =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).symeig(
+    $(bool _eigenvectors)
+  , $(bool _upper)));
+  }|]
+
+tensor_eig_b
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_eig_b _obj _eigenvectors =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).eig(
+    $(bool _eigenvectors)));
+  }|]
+
+tensor_svd_bb
+  :: Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor,Tensor))
+tensor_svd_bb _obj _some _compute_uv =
+  [C.block| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).svd(
+    $(bool _some)
+  , $(bool _compute_uv)));
+  }|]
+
+tensor_cholesky_b
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_cholesky_b _obj _upper =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cholesky(
+    $(bool _upper)));
+  }|]
+
+tensor_cholesky_solve_tb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_cholesky_solve_tb _obj _input2 _upper =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).cholesky_solve(
+    *$(at::Tensor* _input2)
+  , $(bool _upper)));
+  }|]
+
+tensor_solve_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr (Tensor,Tensor))
+tensor_solve_t _obj _A =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).solve(
+    *$(at::Tensor* _A)));
+  }|]
+
+tensor_potri_b
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_potri_b _obj _upper =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).potri(
+    $(bool _upper)));
+  }|]
+
+tensor_pstrf_bs
+  :: Ptr Tensor
+  -> CBool
+  -> Ptr Scalar
+  -> IO (Ptr (Tensor,Tensor))
+tensor_pstrf_bs _obj _upper _tol =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).pstrf(
+    $(bool _upper)
+  , *$(at::Scalar* _tol)));
+  }|]
+
+tensor_qr
+  :: Ptr Tensor
+  -> IO (Ptr (Tensor,Tensor))
+tensor_qr _obj =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).qr(
+    ));
+  }|]
+
+tensor_geqrf
+  :: Ptr Tensor
+  -> IO (Ptr (Tensor,Tensor))
+tensor_geqrf _obj =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).geqrf(
+    ));
+  }|]
+
+tensor_orgqr_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_orgqr_t _obj _input2 =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).orgqr(
+    *$(at::Tensor* _input2)));
+  }|]
+
+tensor_ormqr_ttbb
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> CBool
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_ormqr_ttbb _obj _input2 _input3 _left _transpose =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).ormqr(
+    *$(at::Tensor* _input2)
+  , *$(at::Tensor* _input3)
+  , $(bool _left)
+  , $(bool _transpose)));
+  }|]
+
+tensor_btrifact_b
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_btrifact_b _obj _pivot =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).btrifact(
+    $(bool _pivot)));
+  }|]
+
+tensor_btrifact_with_info_b
+  :: Ptr Tensor
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor,Tensor))
+tensor_btrifact_with_info_b _obj _pivot =
+  [C.block| std::tuple<at::Tensor,at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).btrifact_with_info(
+    $(bool _pivot)));
+  }|]
+
+tensor_btrisolve_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_btrisolve_tt _obj _LU_data _LU_pivots =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).btrisolve(
+    *$(at::Tensor* _LU_data)
+  , *$(at::Tensor* _LU_pivots)));
+  }|]
+
+tensor_multinomial_lbp
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> Ptr Generator
+  -> IO (Ptr Tensor)
+tensor_multinomial_lbp _obj _num_samples _replacement _generator =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).multinomial(
+    $(int64_t _num_samples)
+  , $(bool _replacement)
+  , $(at::Generator * _generator)));
+  }|]
+
+tensor_lgamma
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_lgamma _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lgamma(
+    ));
+  }|]
+
+tensor_digamma
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_digamma _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).digamma(
+    ));
+  }|]
+
+tensor_polygamma_l
+  :: Ptr Tensor
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_polygamma_l _obj _n =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).polygamma(
+    $(int64_t _n)));
+  }|]
+
+tensor_erfinv
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_erfinv _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).erfinv(
+    ));
+  }|]
+
+tensor_frac
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_frac _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).frac(
+    ));
+  }|]
+
+tensor_dist_ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_dist_ts _obj _other _p =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).dist(
+    *$(at::Tensor* _other)
+  , *$(at::Scalar* _p)));
+  }|]
+
+tensor_reciprocal
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_reciprocal _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).reciprocal(
+    ));
+  }|]
+
+tensor_neg
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_neg _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).neg(
+    ));
+  }|]
+
+tensor_atan2_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_atan2_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).atan2(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_lerp_ts
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_lerp_ts _obj _end _weight =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lerp(
+    *$(at::Tensor* _end)
+  , *$(at::Scalar* _weight)));
+  }|]
+
+tensor_lerp_tt
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_lerp_tt _obj _end _weight =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).lerp(
+    *$(at::Tensor* _end)
+  , *$(at::Tensor* _weight)));
+  }|]
+
+tensor_histc_lss
+  :: Ptr Tensor
+  -> Int64
+  -> Ptr Scalar
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_histc_lss _obj _bins _min _max =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).histc(
+    $(int64_t _bins)
+  , *$(at::Scalar* _min)
+  , *$(at::Scalar* _max)));
+  }|]
+
+tensor_sign
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_sign _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).sign(
+    ));
+  }|]
+
+tensor_fmod_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_fmod_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).fmod(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_fmod_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_fmod_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).fmod(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_remainder_s
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_remainder_s _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).remainder(
+    *$(at::Scalar* _other)));
+  }|]
+
+tensor_remainder_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_remainder_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).remainder(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_min_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_min_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).min(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_min
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_min _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).min(
+    ));
+  }|]
+
+tensor_max_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_max_t _obj _other =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).max(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_max
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_max _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).max(
+    ));
+  }|]
+
+tensor_median
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_median _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).median(
+    ));
+  }|]
+
+tensor_sort_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_sort_lb _obj _dim _descending =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).sort(
+    $(int64_t _dim)
+  , $(bool _descending)));
+  }|]
+
+tensor_argsort_lb
+  :: Ptr Tensor
+  -> Int64
+  -> CBool
+  -> IO (Ptr Tensor)
+tensor_argsort_lb _obj _dim _descending =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).argsort(
+    $(int64_t _dim)
+  , $(bool _descending)));
+  }|]
+
+tensor_topk_llbb
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> CBool
+  -> CBool
+  -> IO (Ptr (Tensor,Tensor))
+tensor_topk_llbb _obj _k _dim _largest _sorted =
+  [C.block| std::tuple<at::Tensor,at::Tensor>* { return new std::tuple<at::Tensor,at::Tensor>((*$(at::Tensor* _obj)).topk(
+    $(int64_t _k)
+  , $(int64_t _dim)
+  , $(bool _largest)
+  , $(bool _sorted)));
+  }|]
+
+tensor_all
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_all _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).all(
+    ));
+  }|]
+
+tensor_any
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_any _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).any(
+    ));
+  }|]
+
+tensor_renorm_sls
+  :: Ptr Tensor
+  -> Ptr Scalar
+  -> Int64
+  -> Ptr Scalar
+  -> IO (Ptr Tensor)
+tensor_renorm_sls _obj _p _dim _maxnorm =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).renorm(
+    *$(at::Scalar* _p)
+  , $(int64_t _dim)
+  , *$(at::Scalar* _maxnorm)));
+  }|]
+
+tensor_unfold_lll
+  :: Ptr Tensor
+  -> Int64
+  -> Int64
+  -> Int64
+  -> IO (Ptr Tensor)
+tensor_unfold_lll _obj _dimension _size _step =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).unfold(
+    $(int64_t _dimension)
+  , $(int64_t _size)
+  , $(int64_t _step)));
+  }|]
+
+tensor_equal_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (CBool)
+tensor_equal_t _obj _other =
+  [C.block| bool { return ((*$(at::Tensor* _obj)).equal(
+    *$(at::Tensor* _other)));
+  }|]
+
+tensor_pow_t
+  :: Ptr Tensor
+  -> Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_pow_t _obj _exponent =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).pow(
+    *$(at::Tensor* _exponent)));
+  }|]
+
+tensor_alias
+  :: Ptr Tensor
+  -> IO (Ptr Tensor)
+tensor_alias _obj =
+  [C.block| at::Tensor* { return new at::Tensor((*$(at::Tensor* _obj)).alias(
     ));
   }|]
 

--- a/ffi/src/Aten/Unmanaged/Type/TensorOptions.hs
+++ b/ffi/src/Aten/Unmanaged/Type/TensorOptions.hs
@@ -30,10 +30,10 @@ C.include "<vector>"
 
 
 
-newTensorOptions
+newTensorOptions_D
   :: DeviceType
   -> IO (Ptr TensorOptions)
-newTensorOptions _d =
+newTensorOptions_D _d =
   [C.block| at::TensorOptions* { return new at::TensorOptions(
     $(at::DeviceType _d));
   }|]
@@ -48,12 +48,12 @@ instance CppObject TensorOptions where
 
 
 
-tensorOptions_dtype
+tensorOptions_dtype_s
   :: Ptr TensorOptions
   -> ScalarType
   -> IO (Ptr TensorOptions)
-tensorOptions_dtype _obj _t =
-  [C.block| at::TensorOptions* { return new at::TensorOptions($(at::TensorOptions* _obj)->dtype(
+tensorOptions_dtype_s _obj _t =
+  [C.block| at::TensorOptions* { return new at::TensorOptions((*$(at::TensorOptions* _obj)).dtype(
     $(at::ScalarType _t)));
   }|]
 

--- a/ffi/test/MemorySpec.hs
+++ b/ffi/test/MemorySpec.hs
@@ -39,19 +39,19 @@ spec = do
 fromList :: [Int64] -> IO (ForeignPtr IntArray)
 fromList dims = do
   ary <- newIntArray
-  forM_ dims $ intArray_push_back ary
+  forM_ dims $ intArray_push_back_l ary
   return ary
 
 newTensor_zeros :: (ForeignPtr IntArray) -> IO (ForeignPtr Tensor)
 newTensor_zeros dims = do
-    to <- newTensorOptions kCPU
-    tod <- tensorOptions_dtype to kByte
+    to <- newTensorOptions_D kCPU
+    tod <- tensorOptions_dtype_s to kByte
     zeros_lo dims tod
 
 totalDim :: (ForeignPtr IntArray) -> IO Int64
 totalDim dims = do
   size <- intArray_size dims
-  dims' <- forM [0..(size-1)] $ \i -> intArray_at dims i
+  dims' <- forM [0..(size-1)] $ \i -> intArray_at_s dims i
   return $ sum dims'
 
 iterator :: (ForeignPtr IntArray) -> Int -> IO ()

--- a/ffi/test/Spec.hs
+++ b/ffi/test/Spec.hs
@@ -22,11 +22,11 @@ main = hspec $ do
 createSpec :: Spec
 createSpec = do
   it "Create Tensor" $ do
-    to <- newTensorOptions kCPU
+    to <- newTensorOptions_D kCPU
     dsize <- newIntArray
-    intArray_push_back dsize 2
-    intArray_push_back dsize 2
-    tod <- tensorOptions_dtype to kByte
+    intArray_push_back_l dsize 2
+    intArray_push_back_l dsize 2
+    tod <- tensorOptions_dtype_s to kByte
     ten <- zeros_lo dsize tod
     tensor_print ten
     return ()

--- a/spec/cppclass/scalar.yaml
+++ b/spec/cppclass/scalar.yaml
@@ -3,6 +3,6 @@ cppname: at::Scalar
 hsname: Scalar
 constructors:
 - new() -> Scalar
-- new_int(int a) -> Scalar
-- new_double(double a) -> Scalar
+- new(int a) -> Scalar
+- new(double a) -> Scalar
 methods: []

--- a/spec/cppclass/tensor.yaml
+++ b/spec/cppclass/tensor.yaml
@@ -3,18 +3,15 @@ cppname: at::Tensor
 hsname: Tensor
 constructors:
 - new() -> Tensor
-- new_Tensor(Tensor x) -> Tensor
+- new(Tensor x) -> Tensor
 methods:
 - dim() -> int64_t
 - storage_offset() -> int64_t
 - defined() -> bool
 - reset() -> void
-#- operator=(Tensor x) -> Tensor
-#- operator=(Tensor x) -> Tensor
-#- operator=(Scalar v) -> Tensor
-#- operator=(Tensor) -> Tensor
-#- operator=(Tensor) -> Tensor
-#- is_same(Tensor other) -> bool
+#- operator=(Tensor x) -> void
+#- operator=(Scalar v) -> void
+- is_same(Tensor other) -> bool
 - use_count() -> size_t
 - weak_use_count() -> size_t
 #- toString() -> char*
@@ -28,12 +25,12 @@ methods:
 #- type() -> Type
 #- type_id() -> TensorTypeId
 #- scalar_type() -> ScalarType
-#- has_storage() -> bool
+- has_storage() -> bool
 #- storage() -> Storage
-#- is_alias_of(at::Tensor other) -> bool
+- is_alias_of(Tensor other) -> bool
 #- toType(Type  t, bool non_blocking=false) -> Tensor
-#- copy_(Tensor  src, bool non_blocking=false) -> Tensor
-#- toType(ScalarType t) -> Tensor
+- copy_(Tensor  src, bool non_blocking=false) -> Tensor
+- toType(ScalarType t) -> Tensor
 #- toBackend(Backend b) -> Tensor
 - is_variable() -> bool
 #- layout() -> Layout
@@ -43,7 +40,7 @@ methods:
 - is_cuda() -> bool
 - is_hip() -> bool
 - is_sparse() -> bool
-#- options() -> TensorOptions
+- options() -> TensorOptions
 #- data() -> T*
 #- item() -> T
 - print() -> void
@@ -52,423 +49,422 @@ methods:
 #- packed_accessor() -> PackedTensorAccessor<T,N,PtrTraits,index_t>
 #- packed_accessor() -> PackedTensorAccessor<T,N>
 #- operator-() -> Tensor
-#- operator+=(Tensor  other) -> Tensor
-#- operator+=(Scalar other) -> Tensor
-#- operator-=(Tensor  other) -> Tensor
-#- operator-=(Scalar other) -> Tensor
-#- operator*=(Tensor  other) -> Tensor
-#- operator*=(Scalar other) -> Tensor
+- operator+=(Tensor  other) -> void
+- operator+=(Scalar other) -> void
+- operator-=(Tensor  other) -> void
+- operator-=(Scalar other) -> void
+- operator*=(Tensor  other) -> void
+- operator*=(Scalar other) -> void
 #- operator/=(Tensor  other) -> Tensor
 #- operator/=(Scalar other) -> Tensor
-#- operator[](Scalar index) -> Tensor
-#- operator[](Tensor index) -> Tensor
-#- operator[](int64_t index) -> Tensor
-#- cpu() -> Tensor
-#- cuda() -> Tensor
-#- hip() -> Tensor
-#- set_requires_grad(bool requires_grad) -> Tensor
-#- requires_grad() -> bool
-#- grad() -> Tensor
-#- grad() -> Tensor
-#- set_data(Tensor new_data) -> void
-#- abs() -> Tensor
-#- abs_() -> Tensor
-#- acos() -> Tensor
-#- acos_() -> Tensor
-#- add(Tensor  other, Scalar alpha=1) -> Tensor
-#- add_(Tensor  other, Scalar alpha=1) -> Tensor
-#- add(Scalar other, Scalar alpha=1) -> Tensor
-#- add_(Scalar other, Scalar alpha=1) -> Tensor
-#- addmv(Tensor  mat, Tensor  vec, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- addmv_(Tensor  mat, Tensor  vec, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- addr(Tensor  vec1, Tensor  vec2, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- addr_(Tensor  vec1, Tensor  vec2, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- all(int64_t dim, bool keepdim=false) -> Tensor
-#- allclose(Tensor  other, double rtol=1e-05, double atol=1e-08, bool equal_nan=false) -> bool
-#- any(int64_t dim, bool keepdim=false) -> Tensor
-#- argmax(int64_t dim, bool keepdim=false) -> Tensor
-#- argmax() -> Tensor
-#- argmin(int64_t dim, bool keepdim=false) -> Tensor
-#- argmin() -> Tensor
-#- asin() -> Tensor
-#- asin_() -> Tensor
-#- atan() -> Tensor
-#- atan_() -> Tensor
-#- baddbmm(Tensor  batch1, Tensor  batch2, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- baddbmm_(Tensor  batch1, Tensor  batch2, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- bernoulli(Generator * generator=nullptr) -> Tensor
-#- bernoulli_(Tensor  p, Generator * generator=nullptr) -> Tensor
-#- bernoulli_(double p=0.5, Generator * generator=nullptr) -> Tensor
-#- bernoulli(double p, Generator * generator=nullptr) -> Tensor
-#- bincount(Tensor  weights={}, int64_t minlength=0) -> Tensor
-#- bmm(Tensor  mat2) -> Tensor
-#- ceil() -> Tensor
-#- ceil_() -> Tensor
+- operator[](Scalar index) -> Tensor
+- operator[](Tensor index) -> Tensor
+- operator[](int64_t index) -> Tensor
+- cpu() -> Tensor
+- cuda() -> Tensor
+- hip() -> Tensor
+- set_requires_grad(bool requires_grad) -> Tensor
+- requires_grad() -> bool
+- grad() -> Tensor
+- set_data(Tensor new_data) -> void
+- abs() -> Tensor
+- abs_() -> Tensor
+- acos() -> Tensor
+- acos_() -> Tensor
+- add(Tensor  other, Scalar alpha=1) -> Tensor
+- add_(Tensor  other, Scalar alpha=1) -> Tensor
+- add(Scalar other, Scalar alpha=1) -> Tensor
+- add_(Scalar other, Scalar alpha=1) -> Tensor
+- addmv(Tensor  mat, Tensor  vec, Scalar beta=1, Scalar alpha=1) -> Tensor
+- addmv_(Tensor  mat, Tensor  vec, Scalar beta=1, Scalar alpha=1) -> Tensor
+- addr(Tensor  vec1, Tensor  vec2, Scalar beta=1, Scalar alpha=1) -> Tensor
+- addr_(Tensor  vec1, Tensor  vec2, Scalar beta=1, Scalar alpha=1) -> Tensor
+- all(int64_t dim, bool keepdim=false) -> Tensor
+- allclose(Tensor  other, double rtol=1e-05, double atol=1e-08, bool equal_nan=false) -> bool
+- any(int64_t dim, bool keepdim=false) -> Tensor
+- argmax(int64_t dim, bool keepdim=false) -> Tensor
+- argmax() -> Tensor
+- argmin(int64_t dim, bool keepdim=false) -> Tensor
+- argmin() -> Tensor
+- asin() -> Tensor
+- asin_() -> Tensor
+- atan() -> Tensor
+- atan_() -> Tensor
+- baddbmm(Tensor  batch1, Tensor  batch2, Scalar beta=1, Scalar alpha=1) -> Tensor
+- baddbmm_(Tensor  batch1, Tensor  batch2, Scalar beta=1, Scalar alpha=1) -> Tensor
+- bernoulli(Generator * generator=nullptr) -> Tensor
+- bernoulli_(Tensor  p, Generator * generator=nullptr) -> Tensor
+- bernoulli_(double p=0.5, Generator * generator=nullptr) -> Tensor
+- bernoulli(double p, Generator * generator=nullptr) -> Tensor
+- bincount(Tensor  weights={}, int64_t minlength=0) -> Tensor
+- bmm(Tensor  mat2) -> Tensor
+- ceil() -> Tensor
+- ceil_() -> Tensor
 #- chunk(int64_t chunks, int64_t dim=0) -> std::vector<Tensor>
-#- clamp_max(Scalar max) -> Tensor
-#- clamp_max_(Scalar max) -> Tensor
-#- clamp_min(Scalar min) -> Tensor
-#- clamp_min_(Scalar min) -> Tensor
-#- contiguous() -> Tensor
-#- cos() -> Tensor
-#- cos_() -> Tensor
-#- cosh() -> Tensor
-#- cosh_() -> Tensor
-#- cumsum(int64_t dim, ScalarType dtype) -> Tensor
-#- cumsum(int64_t dim) -> Tensor
-#- cumprod(int64_t dim, ScalarType dtype) -> Tensor
-#- cumprod(int64_t dim) -> Tensor
-#- det() -> Tensor
-#- diag_embed(int64_t offset=0, int64_t dim1=-2, int64_t dim2=-1) -> Tensor
-#- diagflat(int64_t offset=0) -> Tensor
-#- diagonal(int64_t offset=0, int64_t dim1=0, int64_t dim2=1) -> Tensor
-#- div(Tensor  other) -> Tensor
-#- div_(Tensor  other) -> Tensor
-#- div(Scalar other) -> Tensor
-#- div_(Scalar other) -> Tensor
-#- dot(Tensor  tensor) -> Tensor
-#- resize_(IntArrayRef size) -> Tensor
-#- erf() -> Tensor
-#- erf_() -> Tensor
-#- erfc() -> Tensor
-#- erfc_() -> Tensor
-#- exp() -> Tensor
-#- exp_() -> Tensor
-#- expm1() -> Tensor
-#- expm1_() -> Tensor
-#- expand(IntArrayRef size, bool implicit=false) -> Tensor
-#- expand_as(Tensor  other) -> Tensor
-#- flatten(int64_t start_dim=0, int64_t end_dim=-1) -> Tensor
-#- fill_(Scalar value) -> Tensor
-#- fill_(Tensor  value) -> Tensor
-#- floor() -> Tensor
-#- floor_() -> Tensor
-#- ger(Tensor  vec2) -> Tensor
-#- fft(int64_t signal_ndim, bool normalized=false) -> Tensor
-#- ifft(int64_t signal_ndim, bool normalized=false) -> Tensor
-#- rfft(int64_t signal_ndim, bool normalized=false, bool onesided=true) -> Tensor
-#- irfft(int64_t signal_ndim, bool normalized=false, bool onesided=true, IntArrayRef signal_sizes={}) -> Tensor
-#- index(TensorList indices) -> Tensor
-#- index_copy_(int64_t dim, Tensor  index, Tensor  source) -> Tensor
-#- index_copy(int64_t dim, Tensor  index, Tensor  source) -> Tensor
-#- index_put_(TensorList indices, Tensor  values, bool accumulate=false) -> Tensor
-#- index_put(TensorList indices, Tensor  values, bool accumulate=false) -> Tensor
-#- inverse() -> Tensor
-#- isclose(Tensor  other, double rtol=1e-05, double atol=1e-08, bool equal_nan=false) -> Tensor
-#- is_distributed() -> bool
-#- is_floating_point() -> bool
-#- is_complex() -> bool
-#- is_nonzero() -> bool
-#- is_same_size(Tensor  other) -> bool
-#- is_signed() -> bool
-#- kthvalue(int64_t k, int64_t dim=-1, bool keepdim=false) -> std::tuple<Tensor,Tensor>
-#- log() -> Tensor
-#- log_() -> Tensor
-#- log10() -> Tensor
-#- log10_() -> Tensor
-#- log1p() -> Tensor
-#- log1p_() -> Tensor
-#- log2() -> Tensor
-#- log2_() -> Tensor
-#- logdet() -> Tensor
-#- log_softmax(int64_t dim, ScalarType dtype) -> Tensor
-#- log_softmax(int64_t dim) -> Tensor
-#- logsumexp(IntArrayRef dim, bool keepdim=false) -> Tensor
-#- matmul(Tensor  other) -> Tensor
-#- matrix_power(int64_t n) -> Tensor
-#- max(int64_t dim, bool keepdim=false) -> std::tuple<Tensor,Tensor>
-#- max_values(IntArrayRef dim, bool keepdim=false) -> Tensor
-#- mean(ScalarType dtype) -> Tensor
-#- mean() -> Tensor
-#- mean(IntArrayRef dim, bool keepdim, ScalarType dtype) -> Tensor
-#- mean(IntArrayRef dim, bool keepdim=false) -> Tensor
-#- mean(IntArrayRef dim, ScalarType dtype) -> Tensor
-#- median(int64_t dim, bool keepdim=false) -> std::tuple<Tensor,Tensor>
-#- min(int64_t dim, bool keepdim=false) -> std::tuple<Tensor,Tensor>
-#- min_values(IntArrayRef dim, bool keepdim=false) -> Tensor
-#- mm(Tensor  mat2) -> Tensor
-#- mode(int64_t dim=-1, bool keepdim=false) -> std::tuple<Tensor,Tensor>
-#- mul(Tensor  other) -> Tensor
-#- mul_(Tensor  other) -> Tensor
-#- mul(Scalar other) -> Tensor
-#- mul_(Scalar other) -> Tensor
-#- mv(Tensor  vec) -> Tensor
-#- mvlgamma(int64_t p) -> Tensor
-#- mvlgamma_(int64_t p) -> Tensor
-#- narrow_copy(int64_t dim, int64_t start, int64_t length) -> Tensor
-#- narrow(int64_t dim, int64_t start, int64_t length) -> Tensor
-#- permute(IntArrayRef dims) -> Tensor
-#- pin_memory() -> Tensor
-#- pinverse(double rcond=1e-15) -> Tensor
-#- repeat(IntArrayRef repeats) -> Tensor
-#- reshape(IntArrayRef shape) -> Tensor
-#- reshape_as(Tensor  other) -> Tensor
-#- round() -> Tensor
-#- round_() -> Tensor
-#- relu() -> Tensor
-#- relu_() -> Tensor
-#- prelu(Tensor  weight) -> Tensor
-#- prelu_backward(Tensor  grad_output, Tensor  weight) -> std::tuple<Tensor,Tensor>
-#- hardshrink(Scalar lambd=0.5) -> Tensor
-#- hardshrink_backward(Tensor  grad_out, Scalar lambd) -> Tensor
-#- rsqrt() -> Tensor
-#- rsqrt_() -> Tensor
-#- select(int64_t dim, int64_t index) -> Tensor
-#- sigmoid() -> Tensor
-#- sigmoid_() -> Tensor
-#- sin() -> Tensor
-#- sin_() -> Tensor
-#- sinh() -> Tensor
-#- sinh_() -> Tensor
-#- detach() -> Tensor
-#- detach_() -> Tensor
-#- size(int64_t dim) -> int64_t
-#- slice(int64_t dim=0, int64_t start=0, int64_t end=9223372036854775807, int64_t step=1) -> Tensor
-#- slogdet() -> std::tuple<Tensor,Tensor>
-#- smm(Tensor  mat2) -> Tensor
-#- softmax(int64_t dim, ScalarType dtype) -> Tensor
-#- softmax(int64_t dim) -> Tensor
+- clamp_max(Scalar max) -> Tensor
+- clamp_max_(Scalar max) -> Tensor
+- clamp_min(Scalar min) -> Tensor
+- clamp_min_(Scalar min) -> Tensor
+- contiguous() -> Tensor
+- cos() -> Tensor
+- cos_() -> Tensor
+- cosh() -> Tensor
+- cosh_() -> Tensor
+- cumsum(int64_t dim, ScalarType dtype) -> Tensor
+- cumsum(int64_t dim) -> Tensor
+- cumprod(int64_t dim, ScalarType dtype) -> Tensor
+- cumprod(int64_t dim) -> Tensor
+- det() -> Tensor
+- diag_embed(int64_t offset=0, int64_t dim1=-2, int64_t dim2=-1) -> Tensor
+- diagflat(int64_t offset=0) -> Tensor
+- diagonal(int64_t offset=0, int64_t dim1=0, int64_t dim2=1) -> Tensor
+- div(Tensor  other) -> Tensor
+- div_(Tensor  other) -> Tensor
+- div(Scalar other) -> Tensor
+- div_(Scalar other) -> Tensor
+- dot(Tensor  tensor) -> Tensor
+- resize_(IntArrayRef size) -> Tensor
+- erf() -> Tensor
+- erf_() -> Tensor
+- erfc() -> Tensor
+- erfc_() -> Tensor
+- exp() -> Tensor
+- exp_() -> Tensor
+- expm1() -> Tensor
+- expm1_() -> Tensor
+- expand(IntArrayRef size, bool implicit=false) -> Tensor
+- expand_as(Tensor  other) -> Tensor
+- flatten(int64_t start_dim=0, int64_t end_dim=-1) -> Tensor
+- fill_(Scalar value) -> Tensor
+- fill_(Tensor  value) -> Tensor
+- floor() -> Tensor
+- floor_() -> Tensor
+- ger(Tensor  vec2) -> Tensor
+- fft(int64_t signal_ndim, bool normalized=false) -> Tensor
+- ifft(int64_t signal_ndim, bool normalized=false) -> Tensor
+- rfft(int64_t signal_ndim, bool normalized=false, bool onesided=true) -> Tensor
+- irfft(int64_t signal_ndim, bool normalized=false, bool onesided=true, IntArrayRef signal_sizes={}) -> Tensor
+- index(TensorList indices) -> Tensor
+- index_copy_(int64_t dim, Tensor  index, Tensor  source) -> Tensor
+- index_copy(int64_t dim, Tensor  index, Tensor  source) -> Tensor
+- index_put_(TensorList indices, Tensor  values, bool accumulate=false) -> Tensor
+- index_put(TensorList indices, Tensor  values, bool accumulate=false) -> Tensor
+- inverse() -> Tensor
+- isclose(Tensor  other, double rtol=1e-05, double atol=1e-08, bool equal_nan=false) -> Tensor
+- is_distributed() -> bool
+- is_floating_point() -> bool
+- is_complex() -> bool
+- is_nonzero() -> bool
+- is_same_size(Tensor  other) -> bool
+- is_signed() -> bool
+- kthvalue(int64_t k, int64_t dim=-1, bool keepdim=false) -> (Tensor,Tensor)
+- log() -> Tensor
+- log_() -> Tensor
+- log10() -> Tensor
+- log10_() -> Tensor
+- log1p() -> Tensor
+- log1p_() -> Tensor
+- log2() -> Tensor
+- log2_() -> Tensor
+- logdet() -> Tensor
+- log_softmax(int64_t dim, ScalarType dtype) -> Tensor
+- log_softmax(int64_t dim) -> Tensor
+- logsumexp(IntArrayRef dim, bool keepdim=false) -> Tensor
+- matmul(Tensor  other) -> Tensor
+- matrix_power(int64_t n) -> Tensor
+- max(int64_t dim, bool keepdim=false) -> (Tensor,Tensor)
+- max_values(IntArrayRef dim, bool keepdim=false) -> Tensor
+- mean(ScalarType dtype) -> Tensor
+- mean() -> Tensor
+- mean(IntArrayRef dim, bool keepdim, ScalarType dtype) -> Tensor
+- mean(IntArrayRef dim, bool keepdim=false) -> Tensor
+- mean(IntArrayRef dim, ScalarType dtype) -> Tensor
+- median(int64_t dim, bool keepdim=false) -> (Tensor,Tensor)
+- min(int64_t dim, bool keepdim=false) -> (Tensor,Tensor)
+- min_values(IntArrayRef dim, bool keepdim=false) -> Tensor
+- mm(Tensor  mat2) -> Tensor
+- mode(int64_t dim=-1, bool keepdim=false) -> (Tensor,Tensor)
+- mul(Tensor  other) -> Tensor
+- mul_(Tensor  other) -> Tensor
+- mul(Scalar other) -> Tensor
+- mul_(Scalar other) -> Tensor
+- mv(Tensor  vec) -> Tensor
+- mvlgamma(int64_t p) -> Tensor
+- mvlgamma_(int64_t p) -> Tensor
+- narrow_copy(int64_t dim, int64_t start, int64_t length) -> Tensor
+- narrow(int64_t dim, int64_t start, int64_t length) -> Tensor
+- permute(IntArrayRef dims) -> Tensor
+- pin_memory() -> Tensor
+- pinverse(double rcond=1e-15) -> Tensor
+- repeat(IntArrayRef repeats) -> Tensor
+- reshape(IntArrayRef shape) -> Tensor
+- reshape_as(Tensor  other) -> Tensor
+- round() -> Tensor
+- round_() -> Tensor
+- relu() -> Tensor
+- relu_() -> Tensor
+- prelu(Tensor  weight) -> Tensor
+- prelu_backward(Tensor  grad_output, Tensor  weight) -> (Tensor,Tensor)
+- hardshrink(Scalar lambd=0.5) -> Tensor
+- hardshrink_backward(Tensor  grad_out, Scalar lambd) -> Tensor
+- rsqrt() -> Tensor
+- rsqrt_() -> Tensor
+- select(int64_t dim, int64_t index) -> Tensor
+- sigmoid() -> Tensor
+- sigmoid_() -> Tensor
+- sin() -> Tensor
+- sin_() -> Tensor
+- sinh() -> Tensor
+- sinh_() -> Tensor
+- detach() -> Tensor
+- detach_() -> Tensor
+- size(int64_t dim) -> int64_t
+- slice(int64_t dim=0, int64_t start=0, int64_t end=9223372036854775807, int64_t step=1) -> Tensor
+- slogdet() -> (Tensor,Tensor)
+- smm(Tensor  mat2) -> Tensor
+- softmax(int64_t dim, ScalarType dtype) -> Tensor
+- softmax(int64_t dim) -> Tensor
 #- split(int64_t split_size, int64_t dim=0) -> std::vector<Tensor>
 #- split_with_sizes(IntArrayRef split_sizes, int64_t dim=0) -> std::vector<Tensor>
-#- squeeze() -> Tensor
-#- squeeze(int64_t dim) -> Tensor
-#- squeeze_() -> Tensor
-#- squeeze_(int64_t dim) -> Tensor
-#- sspaddmm(Tensor  mat1, Tensor  mat2, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- stride(int64_t dim) -> int64_t
-#- sum(ScalarType dtype) -> Tensor
-#- sum() -> Tensor
-#- sum(IntArrayRef dim, bool keepdim, ScalarType dtype) -> Tensor
-#- sum(IntArrayRef dim, bool keepdim=false) -> Tensor
-#- sum(IntArrayRef dim, ScalarType dtype) -> Tensor
-#- sum_to_size(IntArrayRef size) -> Tensor
-#- sqrt() -> Tensor
-#- sqrt_() -> Tensor
-#- std(bool unbiased=true) -> Tensor
-#- std(IntArrayRef dim, bool unbiased=true, bool keepdim=false) -> Tensor
-#- prod(ScalarType dtype) -> Tensor
-#- prod() -> Tensor
-#- prod(int64_t dim, bool keepdim, ScalarType dtype) -> Tensor
-#- prod(int64_t dim, bool keepdim=false) -> Tensor
-#- prod(int64_t dim, ScalarType dtype) -> Tensor
-#- t() -> Tensor
-#- t_() -> Tensor
-#- tan() -> Tensor
-#- tan_() -> Tensor
-#- tanh() -> Tensor
-#- tanh_() -> Tensor
-#- transpose(int64_t dim0, int64_t dim1) -> Tensor
-#- transpose_(int64_t dim0, int64_t dim1) -> Tensor
-#- flip(IntArrayRef dims) -> Tensor
-#- roll(IntArrayRef shifts, IntArrayRef dims={}) -> Tensor
-#- rot90(int64_t k=1, IntArrayRef dims={0,1}) -> Tensor
-#- trunc() -> Tensor
-#- trunc_() -> Tensor
-#- type_as(Tensor  other) -> Tensor
-#- unsqueeze(int64_t dim) -> Tensor
-#- unsqueeze_(int64_t dim) -> Tensor
-#- var(bool unbiased=true) -> Tensor
-#- var(IntArrayRef dim, bool unbiased=true, bool keepdim=false) -> Tensor
-#- view_as(Tensor  other) -> Tensor
-#- where(Tensor  condition, Tensor  other) -> Tensor
-#- norm(Scalar p=2) -> Tensor
-#- clone() -> Tensor
-#- resize_as_(Tensor  the_template) -> Tensor
-#- pow(Scalar exponent) -> Tensor
-#- zero_() -> Tensor
-#- sub(Tensor  other, Scalar alpha=1) -> Tensor
-#- sub_(Tensor  other, Scalar alpha=1) -> Tensor
-#- sub(Scalar other, Scalar alpha=1) -> Tensor
-#- sub_(Scalar other, Scalar alpha=1) -> Tensor
-#- addmm(Tensor  mat1, Tensor  mat2, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- addmm_(Tensor  mat1, Tensor  mat2, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- sparse_resize_(IntArrayRef size, int64_t sparse_dim, int64_t dense_dim) -> Tensor
-#- sparse_resize_and_clear_(IntArrayRef size, int64_t sparse_dim, int64_t dense_dim) -> Tensor
-#- sparse_mask(SparseTensorRef mask) -> Tensor
-#- to_dense() -> Tensor
-#- sparse_dim() -> int64_t
-#- _dimI() -> int64_t
-#- dense_dim() -> int64_t
-#- _dimV() -> int64_t
-#- _nnz() -> int64_t
-#- coalesce() -> Tensor
-#- is_coalesced() -> bool
-#- _indices() -> Tensor
-#- _values() -> Tensor
-#- _coalesced_(bool coalesced) -> Tensor
-#- indices() -> Tensor
-#- values() -> Tensor
-#- numel() -> int64_t
+- squeeze() -> Tensor
+- squeeze(int64_t dim) -> Tensor
+- squeeze_() -> Tensor
+- squeeze_(int64_t dim) -> Tensor
+- sspaddmm(Tensor  mat1, Tensor  mat2, Scalar beta=1, Scalar alpha=1) -> Tensor
+- stride(int64_t dim) -> int64_t
+- sum(ScalarType dtype) -> Tensor
+- sum() -> Tensor
+- sum(IntArrayRef dim, bool keepdim, ScalarType dtype) -> Tensor
+- sum(IntArrayRef dim, bool keepdim=false) -> Tensor
+- sum(IntArrayRef dim, ScalarType dtype) -> Tensor
+- sum_to_size(IntArrayRef size) -> Tensor
+- sqrt() -> Tensor
+- sqrt_() -> Tensor
+- std(bool unbiased=true) -> Tensor
+- std(IntArrayRef dim, bool unbiased=true, bool keepdim=false) -> Tensor
+- prod(ScalarType dtype) -> Tensor
+- prod() -> Tensor
+- prod(int64_t dim, bool keepdim, ScalarType dtype) -> Tensor
+- prod(int64_t dim, bool keepdim=false) -> Tensor
+- prod(int64_t dim, ScalarType dtype) -> Tensor
+- t() -> Tensor
+- t_() -> Tensor
+- tan() -> Tensor
+- tan_() -> Tensor
+- tanh() -> Tensor
+- tanh_() -> Tensor
+- transpose(int64_t dim0, int64_t dim1) -> Tensor
+- transpose_(int64_t dim0, int64_t dim1) -> Tensor
+- flip(IntArrayRef dims) -> Tensor
+- roll(IntArrayRef shifts, IntArrayRef dims={}) -> Tensor
+- rot90(int64_t k=1, IntArrayRef dims={0,1}) -> Tensor
+- trunc() -> Tensor
+- trunc_() -> Tensor
+- type_as(Tensor  other) -> Tensor
+- unsqueeze(int64_t dim) -> Tensor
+- unsqueeze_(int64_t dim) -> Tensor
+- var(bool unbiased=true) -> Tensor
+- var(IntArrayRef dim, bool unbiased=true, bool keepdim=false) -> Tensor
+- view_as(Tensor  other) -> Tensor
+- where(Tensor  condition, Tensor  other) -> Tensor
+- norm(Scalar p=2) -> Tensor
+- clone() -> Tensor
+- resize_as_(Tensor  the_template) -> Tensor
+- pow(Scalar exponent) -> Tensor
+- zero_() -> Tensor
+- sub(Tensor  other, Scalar alpha=1) -> Tensor
+- sub_(Tensor  other, Scalar alpha=1) -> Tensor
+- sub(Scalar other, Scalar alpha=1) -> Tensor
+- sub_(Scalar other, Scalar alpha=1) -> Tensor
+- addmm(Tensor  mat1, Tensor  mat2, Scalar beta=1, Scalar alpha=1) -> Tensor
+- addmm_(Tensor  mat1, Tensor  mat2, Scalar beta=1, Scalar alpha=1) -> Tensor
+- sparse_resize_(IntArrayRef size, int64_t sparse_dim, int64_t dense_dim) -> Tensor
+- sparse_resize_and_clear_(IntArrayRef size, int64_t sparse_dim, int64_t dense_dim) -> Tensor
+- sparse_mask(SparseTensorRef mask) -> Tensor
+- to_dense() -> Tensor
+- sparse_dim() -> int64_t
+- _dimI() -> int64_t
+- dense_dim() -> int64_t
+- _dimV() -> int64_t
+- _nnz() -> int64_t
+- coalesce() -> Tensor
+- is_coalesced() -> bool
+- _indices() -> Tensor
+- _values() -> Tensor
+- _coalesced_(bool coalesced) -> Tensor
+- indices() -> Tensor
+- values() -> Tensor
+- numel() -> int64_t
 #- unbind(int64_t dim=0) -> std::vector<Tensor>
-#- to_sparse(int64_t sparse_dim) -> Tensor
-#- to_sparse() -> Tensor
-#- to(TensorOptions  options, bool non_blocking=false, bool copy=false) -> Tensor
-#- to(Device device, ScalarType dtype, bool non_blocking=false, bool copy=false) -> Tensor
-#- to(ScalarType dtype, bool non_blocking=false, bool copy=false) -> Tensor
-#- to(Tensor  other, bool non_blocking=false, bool copy=false) -> Tensor
-#- item() -> Scalar
-#- data_ptr() -> void*
-#- set_(Storage source) -> Tensor
-#- set_(Storage source, int64_t storage_offset, IntArrayRef size, IntArrayRef stride={}) -> Tensor
-#- set_(Tensor  source) -> Tensor
-#- set_() -> Tensor
-#- is_set_to(Tensor  tensor) -> bool
-#- masked_fill_(Tensor  mask, Scalar value) -> Tensor
-#- masked_fill(Tensor  mask, Scalar value) -> Tensor
-#- masked_fill_(Tensor  mask, Tensor  value) -> Tensor
-#- masked_fill(Tensor  mask, Tensor  value) -> Tensor
-#- masked_scatter_(Tensor  mask, Tensor  source) -> Tensor
-#- masked_scatter(Tensor  mask, Tensor  source) -> Tensor
-#- view(IntArrayRef size) -> Tensor
-#- put_(Tensor  index, Tensor  source, bool accumulate=false) -> Tensor
-#- index_add_(int64_t dim, Tensor  index, Tensor  source) -> Tensor
-#- index_add(int64_t dim, Tensor  index, Tensor  source) -> Tensor
-#- index_fill_(int64_t dim, Tensor  index, Scalar value) -> Tensor
-#- index_fill(int64_t dim, Tensor  index, Scalar value) -> Tensor
-#- index_fill_(int64_t dim, Tensor  index, Tensor  value) -> Tensor
-#- index_fill(int64_t dim, Tensor  index, Tensor  value) -> Tensor
-#- scatter_(int64_t dim, Tensor  index, Tensor  src) -> Tensor
-#- scatter(int64_t dim, Tensor  index, Tensor  src) -> Tensor
-#- scatter_(int64_t dim, Tensor  index, Scalar value) -> Tensor
-#- scatter(int64_t dim, Tensor  index, Scalar value) -> Tensor
-#- scatter_add_(int64_t dim, Tensor  index, Tensor  src) -> Tensor
-#- scatter_add(int64_t dim, Tensor  index, Tensor  src) -> Tensor
-#- lt_(Scalar other) -> Tensor
-#- lt_(Tensor  other) -> Tensor
-#- gt_(Scalar other) -> Tensor
-#- gt_(Tensor  other) -> Tensor
-#- le_(Scalar other) -> Tensor
-#- le_(Tensor  other) -> Tensor
-#- ge_(Scalar other) -> Tensor
-#- ge_(Tensor  other) -> Tensor
-#- eq_(Scalar other) -> Tensor
-#- eq_(Tensor  other) -> Tensor
-#- ne_(Scalar other) -> Tensor
-#- ne_(Tensor  other) -> Tensor
-#- __and__(Scalar other) -> Tensor
-#- __and__(Tensor  other) -> Tensor
-#- __iand__(Scalar other) -> Tensor
-#- __iand__(Tensor  other) -> Tensor
-#- __or__(Scalar other) -> Tensor
-#- __or__(Tensor  other) -> Tensor
-#- __ior__(Scalar other) -> Tensor
-#- __ior__(Tensor  other) -> Tensor
-#- __xor__(Scalar other) -> Tensor
-#- __xor__(Tensor  other) -> Tensor
-#- __ixor__(Scalar other) -> Tensor
-#- __ixor__(Tensor  other) -> Tensor
-#- __lshift__(Scalar other) -> Tensor
-#- __lshift__(Tensor  other) -> Tensor
-#- __ilshift__(Scalar other) -> Tensor
-#- __ilshift__(Tensor  other) -> Tensor
-#- __rshift__(Scalar other) -> Tensor
-#- __rshift__(Tensor  other) -> Tensor
-#- __irshift__(Scalar other) -> Tensor
-#- __irshift__(Tensor  other) -> Tensor
-#- lgamma_() -> Tensor
-#- atan2_(Tensor  other) -> Tensor
-#- tril_(int64_t diagonal=0) -> Tensor
-#- triu_(int64_t diagonal=0) -> Tensor
-#- digamma_() -> Tensor
-#- polygamma_(int64_t n) -> Tensor
-#- erfinv_() -> Tensor
-#- frac_() -> Tensor
-#- renorm_(Scalar p, int64_t dim, Scalar maxnorm) -> Tensor
-#- reciprocal_() -> Tensor
-#- neg_() -> Tensor
-#- pow_(Scalar exponent) -> Tensor
-#- pow_(Tensor  exponent) -> Tensor
-#- lerp_(Tensor  end, Scalar weight) -> Tensor
-#- lerp_(Tensor  end, Tensor  weight) -> Tensor
-#- sign_() -> Tensor
-#- fmod_(Scalar other) -> Tensor
-#- fmod_(Tensor  other) -> Tensor
-#- remainder_(Scalar other) -> Tensor
-#- remainder_(Tensor  other) -> Tensor
-#- addbmm_(Tensor  batch1, Tensor  batch2, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- addbmm(Tensor  batch1, Tensor  batch2, Scalar beta=1, Scalar alpha=1) -> Tensor
-#- addcmul_(Tensor  tensor1, Tensor  tensor2, Scalar value=1) -> Tensor
-#- addcdiv_(Tensor  tensor1, Tensor  tensor2, Scalar value=1) -> Tensor
-#- random_(int64_t from, int64_t to, Generator * generator=nullptr) -> Tensor
-#- random_(int64_t to, Generator * generator=nullptr) -> Tensor
-#- random_(Generator * generator=nullptr) -> Tensor
-#- uniform_(double from=0, double to=1, Generator * generator=nullptr) -> Tensor
-#- normal_(double mean=0, double std=1, Generator * generator=nullptr) -> Tensor
-#- cauchy_(double median=0, double sigma=1, Generator * generator=nullptr) -> Tensor
-#- log_normal_(double mean=1, double std=2, Generator * generator=nullptr) -> Tensor
-#- exponential_(double lambd=1, Generator * generator=nullptr) -> Tensor
-#- geometric_(double p, Generator * generator=nullptr) -> Tensor
-#- diag(int64_t diagonal=0) -> Tensor
-#- cross(Tensor  other, int64_t dim=-1) -> Tensor
-#- triu(int64_t diagonal=0) -> Tensor
-#- tril(int64_t diagonal=0) -> Tensor
-#- trace() -> Tensor
-#- ne(Scalar other) -> Tensor
-#- ne(Tensor  other) -> Tensor
-#- eq(Scalar other) -> Tensor
-#- eq(Tensor  other) -> Tensor
-#- ge(Scalar other) -> Tensor
-#- ge(Tensor  other) -> Tensor
-#- le(Scalar other) -> Tensor
-#- le(Tensor  other) -> Tensor
-#- gt(Scalar other) -> Tensor
-#- gt(Tensor  other) -> Tensor
-#- lt(Scalar other) -> Tensor
-#- lt(Tensor  other) -> Tensor
-#- take(Tensor  index) -> Tensor
-#- index_select(int64_t dim, Tensor  index) -> Tensor
-#- masked_select(Tensor  mask) -> Tensor
-#- nonzero() -> Tensor
-#- gather(int64_t dim, Tensor  index, bool sparse_grad=false) -> Tensor
-#- addcmul(Tensor  tensor1, Tensor  tensor2, Scalar value=1) -> Tensor
-#- addcdiv(Tensor  tensor1, Tensor  tensor2, Scalar value=1) -> Tensor
-#- gels(Tensor  A) -> std::tuple<Tensor,Tensor>
-#- trtrs(Tensor  A, bool upper=true, bool transpose=false, bool unitriangular=false) -> std::tuple<Tensor,Tensor>
-#- symeig(bool eigenvectors=false, bool upper=true) -> std::tuple<Tensor,Tensor>
-#- eig(bool eigenvectors=false) -> std::tuple<Tensor,Tensor>
-#- svd(bool some=true, bool compute_uv=true) -> std::tuple<Tensor,Tensor,Tensor>
-#- cholesky(bool upper=false) -> Tensor
-#- cholesky_solve(Tensor  input2, bool upper=false) -> Tensor
-#- solve(Tensor  A) -> std::tuple<Tensor,Tensor>
-#- potri(bool upper=true) -> Tensor
-#- pstrf(bool upper=true, Scalar tol=-1) -> std::tuple<Tensor,Tensor>
-#- qr() -> std::tuple<Tensor,Tensor>
-#- geqrf() -> std::tuple<Tensor,Tensor>
-#- orgqr(Tensor  input2) -> Tensor
-#- ormqr(Tensor  input2, Tensor  input3, bool left=true, bool transpose=false) -> Tensor
-#- btrifact(bool pivot=true) -> std::tuple<Tensor,Tensor>
-#- btrifact_with_info(bool pivot=true) -> std::tuple<Tensor,Tensor,Tensor>
-#- btrisolve(Tensor  LU_data, Tensor  LU_pivots) -> Tensor
-#- multinomial(int64_t num_samples, bool replacement=false, Generator * generator=nullptr) -> Tensor
-#- lgamma() -> Tensor
-#- digamma() -> Tensor
-#- polygamma(int64_t n) -> Tensor
-#- erfinv() -> Tensor
-#- frac() -> Tensor
-#- dist(Tensor  other, Scalar p=2) -> Tensor
-#- reciprocal() -> Tensor
-#- neg() -> Tensor
-#- atan2(Tensor  other) -> Tensor
-#- lerp(Tensor  end, Scalar weight) -> Tensor
-#- lerp(Tensor  end, Tensor  weight) -> Tensor
-#- histc(int64_t bins=100, Scalar min=0, Scalar max=0) -> Tensor
-#- sign() -> Tensor
-#- fmod(Scalar other) -> Tensor
-#- fmod(Tensor  other) -> Tensor
-#- remainder(Scalar other) -> Tensor
-#- remainder(Tensor  other) -> Tensor
-#- min(Tensor  other) -> Tensor
-#- min() -> Tensor
-#- max(Tensor  other) -> Tensor
-#- max() -> Tensor
-#- median() -> Tensor
-#- sort(int64_t dim=-1, bool descending=false) -> std::tuple<Tensor,Tensor>
-#- argsort(int64_t dim=-1, bool descending=false) -> Tensor
-#- topk(int64_t k, int64_t dim=-1, bool largest=true, bool sorted=true) -> std::tuple<Tensor,Tensor>
-#- all() -> Tensor
-#- any() -> Tensor
-#- renorm(Scalar p, int64_t dim, Scalar maxnorm) -> Tensor
-#- unfold(int64_t dimension, int64_t size, int64_t step) -> Tensor
-#- equal(Tensor  other) -> bool
-#- pow(Tensor  exponent) -> Tensor
-#- alias() -> Tensor
+- to_sparse(int64_t sparse_dim) -> Tensor
+- to_sparse() -> Tensor
+- to(TensorOptions  options, bool non_blocking=false, bool copy=false) -> Tensor
+- to(Device device, ScalarType dtype, bool non_blocking=false, bool copy=false) -> Tensor
+- to(ScalarType dtype, bool non_blocking=false, bool copy=false) -> Tensor
+- to(Tensor  other, bool non_blocking=false, bool copy=false) -> Tensor
+- item() -> Scalar
+- data_ptr() -> void*
+- set_(Storage source) -> Tensor
+- set_(Storage source, int64_t storage_offset, IntArrayRef size, IntArrayRef stride={}) -> Tensor
+- set_(Tensor  source) -> Tensor
+- set_() -> Tensor
+- is_set_to(Tensor  tensor) -> bool
+- masked_fill_(Tensor  mask, Scalar value) -> Tensor
+- masked_fill(Tensor  mask, Scalar value) -> Tensor
+- masked_fill_(Tensor  mask, Tensor  value) -> Tensor
+- masked_fill(Tensor  mask, Tensor  value) -> Tensor
+- masked_scatter_(Tensor  mask, Tensor  source) -> Tensor
+- masked_scatter(Tensor  mask, Tensor  source) -> Tensor
+- view(IntArrayRef size) -> Tensor
+- put_(Tensor  index, Tensor  source, bool accumulate=false) -> Tensor
+- index_add_(int64_t dim, Tensor  index, Tensor  source) -> Tensor
+- index_add(int64_t dim, Tensor  index, Tensor  source) -> Tensor
+- index_fill_(int64_t dim, Tensor  index, Scalar value) -> Tensor
+- index_fill(int64_t dim, Tensor  index, Scalar value) -> Tensor
+- index_fill_(int64_t dim, Tensor  index, Tensor  value) -> Tensor
+- index_fill(int64_t dim, Tensor  index, Tensor  value) -> Tensor
+- scatter_(int64_t dim, Tensor  index, Tensor  src) -> Tensor
+- scatter(int64_t dim, Tensor  index, Tensor  src) -> Tensor
+- scatter_(int64_t dim, Tensor  index, Scalar value) -> Tensor
+- scatter(int64_t dim, Tensor  index, Scalar value) -> Tensor
+- scatter_add_(int64_t dim, Tensor  index, Tensor  src) -> Tensor
+- scatter_add(int64_t dim, Tensor  index, Tensor  src) -> Tensor
+- lt_(Scalar other) -> Tensor
+- lt_(Tensor  other) -> Tensor
+- gt_(Scalar other) -> Tensor
+- gt_(Tensor  other) -> Tensor
+- le_(Scalar other) -> Tensor
+- le_(Tensor  other) -> Tensor
+- ge_(Scalar other) -> Tensor
+- ge_(Tensor  other) -> Tensor
+- eq_(Scalar other) -> Tensor
+- eq_(Tensor  other) -> Tensor
+- ne_(Scalar other) -> Tensor
+- ne_(Tensor  other) -> Tensor
+- __and__(Scalar other) -> Tensor
+- __and__(Tensor  other) -> Tensor
+- __iand__(Scalar other) -> Tensor
+- __iand__(Tensor  other) -> Tensor
+- __or__(Scalar other) -> Tensor
+- __or__(Tensor  other) -> Tensor
+- __ior__(Scalar other) -> Tensor
+- __ior__(Tensor  other) -> Tensor
+- __xor__(Scalar other) -> Tensor
+- __xor__(Tensor  other) -> Tensor
+- __ixor__(Scalar other) -> Tensor
+- __ixor__(Tensor  other) -> Tensor
+- __lshift__(Scalar other) -> Tensor
+- __lshift__(Tensor  other) -> Tensor
+- __ilshift__(Scalar other) -> Tensor
+- __ilshift__(Tensor  other) -> Tensor
+- __rshift__(Scalar other) -> Tensor
+- __rshift__(Tensor  other) -> Tensor
+- __irshift__(Scalar other) -> Tensor
+- __irshift__(Tensor  other) -> Tensor
+- lgamma_() -> Tensor
+- atan2_(Tensor  other) -> Tensor
+- tril_(int64_t diagonal=0) -> Tensor
+- triu_(int64_t diagonal=0) -> Tensor
+- digamma_() -> Tensor
+- polygamma_(int64_t n) -> Tensor
+- erfinv_() -> Tensor
+- frac_() -> Tensor
+- renorm_(Scalar p, int64_t dim, Scalar maxnorm) -> Tensor
+- reciprocal_() -> Tensor
+- neg_() -> Tensor
+- pow_(Scalar exponent) -> Tensor
+- pow_(Tensor  exponent) -> Tensor
+- lerp_(Tensor  end, Scalar weight) -> Tensor
+- lerp_(Tensor  end, Tensor  weight) -> Tensor
+- sign_() -> Tensor
+- fmod_(Scalar other) -> Tensor
+- fmod_(Tensor  other) -> Tensor
+- remainder_(Scalar other) -> Tensor
+- remainder_(Tensor  other) -> Tensor
+- addbmm_(Tensor  batch1, Tensor  batch2, Scalar beta=1, Scalar alpha=1) -> Tensor
+- addbmm(Tensor  batch1, Tensor  batch2, Scalar beta=1, Scalar alpha=1) -> Tensor
+- addcmul_(Tensor  tensor1, Tensor  tensor2, Scalar value=1) -> Tensor
+- addcdiv_(Tensor  tensor1, Tensor  tensor2, Scalar value=1) -> Tensor
+- random_(int64_t from, int64_t to, Generator * generator=nullptr) -> Tensor
+- random_(int64_t to, Generator * generator=nullptr) -> Tensor
+- random_(Generator * generator=nullptr) -> Tensor
+- uniform_(double from=0, double to=1, Generator * generator=nullptr) -> Tensor
+- normal_(double mean=0, double std=1, Generator * generator=nullptr) -> Tensor
+- cauchy_(double median=0, double sigma=1, Generator * generator=nullptr) -> Tensor
+- log_normal_(double mean=1, double std=2, Generator * generator=nullptr) -> Tensor
+- exponential_(double lambd=1, Generator * generator=nullptr) -> Tensor
+- geometric_(double p, Generator * generator=nullptr) -> Tensor
+- diag(int64_t diagonal=0) -> Tensor
+- cross(Tensor  other, int64_t dim=-1) -> Tensor
+- triu(int64_t diagonal=0) -> Tensor
+- tril(int64_t diagonal=0) -> Tensor
+- trace() -> Tensor
+- ne(Scalar other) -> Tensor
+- ne(Tensor  other) -> Tensor
+- eq(Scalar other) -> Tensor
+- eq(Tensor  other) -> Tensor
+- ge(Scalar other) -> Tensor
+- ge(Tensor  other) -> Tensor
+- le(Scalar other) -> Tensor
+- le(Tensor  other) -> Tensor
+- gt(Scalar other) -> Tensor
+- gt(Tensor  other) -> Tensor
+- lt(Scalar other) -> Tensor
+- lt(Tensor  other) -> Tensor
+- take(Tensor  index) -> Tensor
+- index_select(int64_t dim, Tensor  index) -> Tensor
+- masked_select(Tensor  mask) -> Tensor
+- nonzero() -> Tensor
+- gather(int64_t dim, Tensor  index, bool sparse_grad=false) -> Tensor
+- addcmul(Tensor  tensor1, Tensor  tensor2, Scalar value=1) -> Tensor
+- addcdiv(Tensor  tensor1, Tensor  tensor2, Scalar value=1) -> Tensor
+- gels(Tensor  A) -> (Tensor,Tensor)
+- trtrs(Tensor  A, bool upper=true, bool transpose=false, bool unitriangular=false) -> (Tensor,Tensor)
+- symeig(bool eigenvectors=false, bool upper=true) -> (Tensor,Tensor)
+- eig(bool eigenvectors=false) -> (Tensor,Tensor)
+- svd(bool some=true, bool compute_uv=true) -> (Tensor,Tensor,Tensor)
+- cholesky(bool upper=false) -> Tensor
+- cholesky_solve(Tensor  input2, bool upper=false) -> Tensor
+- solve(Tensor  A) -> (Tensor,Tensor)
+- potri(bool upper=true) -> Tensor
+- pstrf(bool upper=true, Scalar tol=-1) -> (Tensor,Tensor)
+- qr() -> (Tensor,Tensor)
+- geqrf() -> (Tensor,Tensor)
+- orgqr(Tensor  input2) -> Tensor
+- ormqr(Tensor  input2, Tensor  input3, bool left=true, bool transpose=false) -> Tensor
+- btrifact(bool pivot=true) -> (Tensor,Tensor)
+- btrifact_with_info(bool pivot=true) -> (Tensor,Tensor,Tensor)
+- btrisolve(Tensor  LU_data, Tensor  LU_pivots) -> Tensor
+- multinomial(int64_t num_samples, bool replacement=false, Generator * generator=nullptr) -> Tensor
+- lgamma() -> Tensor
+- digamma() -> Tensor
+- polygamma(int64_t n) -> Tensor
+- erfinv() -> Tensor
+- frac() -> Tensor
+- dist(Tensor  other, Scalar p=2) -> Tensor
+- reciprocal() -> Tensor
+- neg() -> Tensor
+- atan2(Tensor  other) -> Tensor
+- lerp(Tensor  end, Scalar weight) -> Tensor
+- lerp(Tensor  end, Tensor  weight) -> Tensor
+- histc(int64_t bins=100, Scalar min=0, Scalar max=0) -> Tensor
+- sign() -> Tensor
+- fmod(Scalar other) -> Tensor
+- fmod(Tensor  other) -> Tensor
+- remainder(Scalar other) -> Tensor
+- remainder(Tensor  other) -> Tensor
+- min(Tensor  other) -> Tensor
+- min() -> Tensor
+- max(Tensor  other) -> Tensor
+- max() -> Tensor
+- median() -> Tensor
+- sort(int64_t dim=-1, bool descending=false) -> (Tensor,Tensor)
+- argsort(int64_t dim=-1, bool descending=false) -> Tensor
+- topk(int64_t k, int64_t dim=-1, bool largest=true, bool sorted=true) -> (Tensor,Tensor)
+- all() -> Tensor
+- any() -> Tensor
+- renorm(Scalar p, int64_t dim, Scalar maxnorm) -> Tensor
+- unfold(int64_t dimension, int64_t size, int64_t step) -> Tensor
+- equal(Tensor  other) -> bool
+- pow(Tensor  exponent) -> Tensor
+- alias() -> Tensor


### PR DESCRIPTION
I'm thinking of adding the following test.
https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/test/basic.cpp
To add it, we need some assignment-operators(=, []).
But this implementation is not enough.