### PR TITLE
Revert stack for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: update-alternatives --install /usr/bin/python python /usr/bin/python3 1
       - checkout
       - run: git submodule init && git submodule update
-      - run: wget -qO- https://get.haskellstack.org/ | sh
+      - run: wget -qO- https://get.haskellstack.org/ | sed -e 's/^STACK_VERSION=.*/STACK_VERSION="1.9.3"/g' | sh
       - run: gcc --version
       - run: stack --version
       - run: cd deps/ ; ./get-deps.sh USE_BINARY_FOR_CI
@@ -71,7 +71,7 @@ jobs:
       - run: mkdir -p .local/bin
       - run: rm /usr/local/bin/python
       - run: ln -s /usr/local/bin/python3 .local/bin/python
-      - run: wget -qO- https://get.haskellstack.org/ | sh
+      - run: wget -qO- https://get.haskellstack.org/ | sed -e 's/^STACK_VERSION=.*/STACK_VERSION="1.9.3"/g' | sh
       - run: clang --version
       - run: stack --version
       - run: cd deps/ ; ./get-deps.sh USE_BINARY_FOR_CI


### PR DESCRIPTION
CI fails for these issues.
https://github.com/commercialhaskell/stack/issues/4861
https://github.com/commercialhaskell/stack/issues/4896

This PR uses pined stack to pass CI.
 