### PR TITLE
Rename DataType to Dtype

### DIFF
--- a/hasktorch/hasktorch.cabal
+++ b/hasktorch/hasktorch.cabal
@@ -33,6 +33,7 @@ library
                     , ghc-typelits-knownnat
                     , mtl
                     , safe-exceptions
+                    , reflection
 
 test-suite spec
   type:               exitcode-stdio-1.0

--- a/hasktorch/src/Torch/DType.hs
+++ b/hasktorch/src/Torch/DType.hs
@@ -10,36 +10,34 @@ import qualified ATen.Const as ATen
 import qualified ATen.Type as ATen
 import Data.Int
 import Data.Word
+import Data.Reflection
 
 data DType = UInt8 | Int8 | Int16 | Int32 | Int64 | Half | Float | Double
   deriving (Eq, Show)
 
-class Dtype a where
-  dType :: Dtype a => DType
+instance Reifies Word8 DType where
+  reflect _ = UInt8
 
-instance Dtype Word8 where
-  dType = UInt8
+instance Reifies Int8 DType where
+  reflect _ = Int8
 
-instance Dtype Int8 where
-  dType = Int8
+instance Reifies Int16 DType where
+  reflect _ = Int16
 
-instance Dtype Int16 where
-  dType = Int16
+instance Reifies Int32 DType where
+  reflect _ = Int32
 
-instance Dtype Int32 where
-  dType = Int32
+instance Reifies Int DType where
+  reflect _ = Int64
 
-instance Dtype Int where
-  dType = Int64
+instance Reifies Int64 DType where
+  reflect _ = Int64
 
-instance Dtype Int64 where
-  dType = Int64
+instance Reifies Float DType where
+  reflect _ = Float
 
-instance Dtype Float where
-  dType = Float
-
-instance Dtype Double where
-  dType = Double
+instance Reifies Double DType where
+  reflect _ = Double
 
 instance Castable DType ATen.ScalarType where
   cast UInt8  f = f ATen.kByte

--- a/hasktorch/src/Torch/DType.hs
+++ b/hasktorch/src/Torch/DType.hs
@@ -14,32 +14,32 @@ import Data.Word
 data DType = UInt8 | Int8 | Int16 | Int32 | Int64 | Half | Float | Double
   deriving (Eq, Show)
 
-class DataType a where
-  dataType :: DataType a => DType
+class Dtype a where
+  dType :: Dtype a => DType
 
-instance DataType Word8 where
-  dataType = UInt8
+instance Dtype Word8 where
+  dType = UInt8
 
-instance DataType Int8 where
-  dataType = Int8
+instance Dtype Int8 where
+  dType = Int8
 
-instance DataType Int16 where
-  dataType = Int16
+instance Dtype Int16 where
+  dType = Int16
 
-instance DataType Int32 where
-  dataType = Int32
+instance Dtype Int32 where
+  dType = Int32
 
-instance DataType Int where
-  dataType = Int64
+instance Dtype Int where
+  dType = Int64
 
-instance DataType Int64 where
-  dataType = Int64
+instance Dtype Int64 where
+  dType = Int64
 
-instance DataType Float where
-  dataType = Float
+instance Dtype Float where
+  dType = Float
 
-instance DataType Double where
-  dataType = Double
+instance Dtype Double where
+  dType = Double
 
 instance Castable DType ATen.ScalarType where
   cast UInt8  f = f ATen.kByte

--- a/hasktorch/src/Torch/Tensor.hs
+++ b/hasktorch/src/Torch/Tensor.hs
@@ -17,6 +17,8 @@ import Foreign.Storable
 import System.IO.Unsafe
 import Data.Int (Int64)
 import Data.List (intercalate)
+import Data.Proxy
+import Data.Reflection
 import Numeric
 
 import ATen.Cast
@@ -138,9 +140,9 @@ float_opts = withDType Float defaultOpts
 withTensor :: Tensor -> (Ptr () -> IO a) -> IO a
 withTensor t fn = cast t $ \t' -> withForeignPtr t' $ \tensor_ptr -> Unmanaged.tensor_data_ptr tensor_ptr >>= fn
 
-instance (Dtype a, Storable a) => TensorLike a where
+instance (Reifies a DType, Storable a) => TensorLike a where
   asTensor' v opts = unsafePerformIO $ do
-    t <- ((cast2 LibTorch.empty_lo) :: [Int] -> TensorOptions -> IO Tensor) [] $ withDType (dType @a) opts
+    t <- ((cast2 LibTorch.empty_lo) :: [Int] -> TensorOptions -> IO Tensor) [] $ withDType (_dtype @a) opts
     withTensor t $ \ptr -> do
       _pokeElemOff ptr 0 v
     return t
@@ -148,14 +150,14 @@ instance (Dtype a, Storable a) => TensorLike a where
   asTensor v = asTensor' v defaultOpts
 
   asValue t = unsafePerformIO $ do
-    if dType @a == dtype t
+    if _dtype @a == dtype t
     then do
       withTensor t $ \ptr -> do
         _peekElemOff ptr 0 []
     else
       throwIO $ userError $ "The infered DType of asValue is " ++ show (_dtype @a)  ++ ", but the DType of tensor on memory is " ++ show (dtype t) ++ "."
 
-  _dtype = dType @a
+  _dtype = reflect (Proxy :: Proxy a)
   _dims _ = []
   _peekElemOff ptr offset _ = peekElemOff (castPtr ptr) offset
   _pokeElemOff ptr offset v = pokeElemOff (castPtr ptr) offset v


### PR DESCRIPTION
The name of ｀DataType｀ is similar to GHC.Generic's ｀Datatype｀.
To avoid a confusion, this PR changes the name.

