### PR TITLE
Add '--write-ghc-environment-files=always' to setup doctest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,12 +47,11 @@ jobs:
       - run: cabal new-install hspec-discover
       - run:
           name: cabal new-build all
-          command: cabal new-build all --jobs=2
+          command: cabal new-build all --jobs=2 --write-ghc-environment-files=always
           no_output_timeout: 15m
-      - run: cabal new-test ffi --jobs=2
+      - run: cabal new-test all --jobs=2 --write-ghc-environment-files=always
       - run: cabal new-exec codegen-exe
-      - run: cabal new-test ffi --jobs=2
-      - run: cabal new-test hasktorch
+      - run: cabal new-test all --jobs=2 --write-ghc-environment-files=always
       - run: cabal exec xor_mlp
   osx-stack-build:
     macos:


### PR DESCRIPTION
When we use `cabal new-test all`, doctest fails.
Because doctest can not detect the path of pacakges.

The root cause may be related to https://github.com/haskell/cabal/issues/4542.

![image](https://user-images.githubusercontent.com/2469618/61232868-448d6580-a76a-11e9-8932-75fe9f18e263.png)
